### PR TITLE
Fix for BS-11409 - NPE when log level is FINE

### DIFF
--- a/server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java
+++ b/server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java
@@ -79,7 +79,7 @@ public class LoginServlet extends HttpServlet {
         final long tenantId = getTenantId(request, response);
         String redirectURL = request.getParameter(LoginManager.REDIRECT_URL);
         if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.log(Level.FINE, "redirecting to : " + redirectURL + " (" + dropPassword(request.getQueryString()) + ")");
+            LOGGER.log(Level.FINE, "redirecting to : " + redirectURL);
         }
         if (redirectAfterLogin && (redirectURL == null || redirectURL.isEmpty())) {
             redirectURL = LoginManager.DEFAULT_DIRECT_URL;


### PR DESCRIPTION
Removed call to request.getQueryString() in doPost as it will always return null.
