### PR TITLE
BS-7361: increased email domain max length to 6

### DIFF
--- a/forms/forms-server/src/main/java/org/bonitasoft/forms/server/validator/MailValidator.java
+++ b/forms/forms-server/src/main/java/org/bonitasoft/forms/server/validator/MailValidator.java
@@ -34,7 +34,7 @@ public class MailValidator implements IFormFieldValidator {
         if (fieldInput.getValue() instanceof String) {
             final String fieldValue = (String)fieldInput.getValue();
             if (fieldValue != null && fieldValue.length() > 0) {
-    	        return fieldValue.matches("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}$");
+    	        return fieldValue.matches("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$");
     	    } else {
     	        return true;
     	    }


### PR DESCRIPTION
Increased email top level domain max length to 6 (current max length but this will evolve) in email validator in order to allow new TLDs in email addresses such as: graham.smith@liamg.London
