### PR TITLE
Feat/bs 13018/support numeric in contract

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
                 <version>1.7</version>
             </dependency>
             <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>1.9.2</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.1</version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -57,6 +57,10 @@
             <artifactId>commons-fileupload</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.fedorahosted.tennera</groupId>
             <artifactId>jgettext</artifactId>
         </dependency>

--- a/server/src/main/java/org/bonitasoft/console/common/server/utils/ContractTypeConverter.java
+++ b/server/src/main/java/org/bonitasoft/console/common/server/utils/ContractTypeConverter.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+package org.bonitasoft.console.common.server.utils;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.beanutils.ConversionException;
+import org.apache.commons.beanutils.ConvertUtilsBean;
+import org.apache.commons.beanutils.converters.DateConverter;
+import org.bonitasoft.engine.bpm.contract.ComplexInputDefinition;
+import org.bonitasoft.engine.bpm.contract.ContractDefinition;
+import org.bonitasoft.engine.bpm.contract.SimpleInputDefinition;
+import org.bonitasoft.engine.bpm.contract.Type;
+
+/**
+ * @author Anthony Birembaut
+ */
+
+public class ContractTypeConverter {
+
+    public static final String[] ISO_8601_DATE_PATTERNS = new String[] { "yyyy-MM-dd", "yyyy-MM-dd'T'hh:mm:ss", "yyyy-MM-dd'T'hh:mm:ss'Z'",
+            "yyyy-MM-dd'T'hh:mm:ss.SSS'Z'" };
+
+    private final ConvertUtilsBean convertUtilsBean;
+
+    public ContractTypeConverter(final String[] datePatterns) {
+        convertUtilsBean = new ConvertUtilsBean();
+        final DateConverter dateConverter = new DateConverter();
+        dateConverter.setPatterns(datePatterns);
+        convertUtilsBean.register(dateConverter, Date.class);
+    }
+
+    public Object convertToType(final Type type, final Serializable parameterValue) {
+        final Class<? extends Serializable> clazz = getClassFromType(type);
+        return convertToType(clazz, parameterValue);
+    }
+
+    public Map<String, Serializable> getProcessedInput(final ContractDefinition contractDefinition, final Map<String, Serializable> input) {
+        final Map<String, Serializable> processedInputs = new HashMap<String, Serializable>();
+        final Map<String, Serializable> contractDefinitionMap = createContractInputMap(contractDefinition.getSimpleInputs(), contractDefinition.getComplexInputs());
+
+        for (final Entry<String, Serializable> inputEntry : input.entrySet()) {
+            processedInputs.put(inputEntry.getKey(), convertInputToExpectedType(inputEntry.getValue(), contractDefinitionMap.get(inputEntry.getKey())));
+        }
+        return processedInputs;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Serializable convertInputToExpectedType(final Serializable inputValue, final Serializable inputDefinition) {
+        if (inputValue instanceof List) {
+            final List<Serializable> listOfValues = (List<Serializable>) inputValue;
+            final List<Serializable> convertedListOfValues = new ArrayList<Serializable>();
+            for (final Serializable value : listOfValues) {
+                convertedListOfValues.add(convertSingleInputToExpectedType(value, inputDefinition));
+            }
+            return (Serializable) convertedListOfValues;
+        } else {
+            return convertSingleInputToExpectedType(inputValue, inputDefinition);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Serializable convertSingleInputToExpectedType(final Serializable inputValue, final Serializable inputDefinition) {
+        if (inputDefinition == null) {
+            return inputValue;
+        } else if (inputValue instanceof Map) {
+            final Map<String, Serializable> mapOfValues = (Map<String, Serializable>) inputValue;
+            final Map<String, Serializable> convertedMapOfValues = new HashMap<String, Serializable>();
+            final Map<String, Serializable> mapOfInputDefinition = (Map<String, Serializable>) inputDefinition;
+            for (final Entry<String, Serializable> valueEntry : mapOfValues.entrySet()) {
+                final Serializable childInputDefinition = mapOfInputDefinition.get(valueEntry.getKey());
+                Serializable convertedValue;
+                if (valueEntry.getValue() instanceof List) {
+                    convertedValue = convertInputToExpectedType(valueEntry.getValue(), childInputDefinition);
+                } else {
+                    convertedValue = convertSingleInputToExpectedType(valueEntry.getValue(), childInputDefinition);
+                }
+                convertedMapOfValues.put(valueEntry.getKey(), convertedValue);
+            }
+            return (Serializable) convertedMapOfValues;
+        } else {
+            final SimpleInputDefinition simpleInputDefinition = (SimpleInputDefinition) inputDefinition;
+            return (Serializable) convertToType(simpleInputDefinition.getType(), inputValue);
+        }
+    }
+
+    protected Map<String, Serializable> createContractInputMap(final List<SimpleInputDefinition> simpleInputs, final List<ComplexInputDefinition> complexInputs) {
+        final Map<String, Serializable> contractDefinitionMap = new HashMap<String, Serializable>();
+        for (final SimpleInputDefinition simpleInputDefinition : simpleInputs) {
+            contractDefinitionMap.put(simpleInputDefinition.getName(), simpleInputDefinition);
+        }
+        for (final ComplexInputDefinition complexInputDefinition : complexInputs) {
+            contractDefinitionMap.put(complexInputDefinition.getName(),
+                    (Serializable) createContractInputMap(complexInputDefinition.getSimpleInputs(), complexInputDefinition.getComplexInputs()));
+        }
+        return contractDefinitionMap;
+    }
+
+    protected Object convertToType(final Class<? extends Serializable> clazz, final Serializable parameterValue) {
+        try {
+            return convertUtilsBean.convert(parameterValue, clazz);
+        } catch (final ConversionException e) {
+            throw new IllegalArgumentException("unable to parse '" + parameterValue + "' to type " + clazz.getName());
+        }
+    }
+
+    protected Class<? extends Serializable> getClassFromType(final Type type) {
+        switch (type) {
+            case BOOLEAN:
+                return Boolean.class;
+            case DATE:
+                return Date.class;
+            case INTEGER:
+                return Long.class;
+            case DECIMAL:
+                return Double.class;
+            case BYTE_ARRAY:
+                return Byte[].class;
+            default:
+                return String.class;
+        }
+    }
+
+}

--- a/server/src/main/java/org/bonitasoft/web/rest/server/api/bpm/process/ProcessInstantiationResource.java
+++ b/server/src/main/java/org/bonitasoft/web/rest/server/api/bpm/process/ProcessInstantiationResource.java
@@ -16,7 +16,9 @@ package org.bonitasoft.web.rest.server.api.bpm.process;
 import java.io.Serializable;
 import java.util.Map;
 
+import org.bonitasoft.console.common.server.utils.ContractTypeConverter;
 import org.bonitasoft.engine.api.ProcessAPI;
+import org.bonitasoft.engine.bpm.contract.ContractDefinition;
 import org.bonitasoft.engine.bpm.contract.ContractViolationException;
 import org.bonitasoft.engine.bpm.process.ProcessActivationException;
 import org.bonitasoft.engine.bpm.process.ProcessDefinitionNotFoundException;
@@ -34,8 +36,10 @@ public class ProcessInstantiationResource extends CommonResource {
     static final String PROCESS_DEFINITION_ID = "processDefinitionId";
 
     private static final String USER_PARAM = "user";
-    
+
     private final ProcessAPI processAPI;
+
+    protected ContractTypeConverter typeConverterUtil = new ContractTypeConverter(ContractTypeConverter.ISO_8601_DATE_PATTERNS);
 
     public ProcessInstantiationResource(final ProcessAPI processAPI) {
         this.processAPI = processAPI;
@@ -44,25 +48,30 @@ public class ProcessInstantiationResource extends CommonResource {
     @Post("json")
     public ProcessInstance instanciateProcess(final Map<String, Serializable> inputs) throws ProcessDefinitionNotFoundException, ProcessActivationException,
             ProcessExecutionException {
-    	String userId = getRequestParameter(USER_PARAM);
+    	final String userId = getRequestParameter(USER_PARAM);
+        final long processDefinitionId = getProcessDefinitionIdParameter();
         try {
+            final ContractDefinition processContract = processAPI.getProcessContract(processDefinitionId);
+            final Map<String, Serializable> processedInputs = typeConverterUtil.getProcessedInput(processContract, inputs);
         	if (userId == null) {
-        		return processAPI.startProcessWithInputs(getProcessDefinitionIdParameter(), inputs); 			
+                return processAPI.startProcessWithInputs(processDefinitionId, processedInputs);
     		} else {
-    		    return processAPI.startProcessWithInputs(Long.parseLong(userId),getProcessDefinitionIdParameter(), inputs);
+                return processAPI.startProcessWithInputs(Long.parseLong(userId), processDefinitionId, processedInputs);
     		}
-            
         } catch (final ContractViolationException e) {
             manageContractViolationException(e, "Cannot instanciate process task.");
             return null;
+        } catch (final Exception e) {
+            e.printStackTrace();
+            throw e;
         }
     }
 
     protected long getProcessDefinitionIdParameter() {
-        final String taskId = getAttribute(PROCESS_DEFINITION_ID);
-        if (taskId == null) {
+        final String processDefinitionId = getAttribute(PROCESS_DEFINITION_ID);
+        if (processDefinitionId == null) {
             throw new APIException("Attribute '" + PROCESS_DEFINITION_ID + "' is mandatory");
         }
-        return Long.parseLong(taskId);
+        return Long.parseLong(processDefinitionId);
     }
 }

--- a/server/src/test/java/org/bonitasoft/console/common/server/utils/ContractTypeConverterTest.java
+++ b/server/src/test/java/org/bonitasoft/console/common/server/utils/ContractTypeConverterTest.java
@@ -1,0 +1,143 @@
+package org.bonitasoft.console.common.server.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bonitasoft.engine.bpm.contract.ComplexInputDefinition;
+import org.bonitasoft.engine.bpm.contract.ContractDefinition;
+import org.bonitasoft.engine.bpm.contract.SimpleInputDefinition;
+import org.bonitasoft.engine.bpm.contract.Type;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContractTypeConverterTest {
+
+    @Mock
+    ContractDefinition contractDefinition;
+
+    ContractTypeConverter contractTypeConverter = new ContractTypeConverter(ContractTypeConverter.ISO_8601_DATE_PATTERNS);
+
+    @Test
+    public void getProcessedInputs_with_empty_contract_should_return_unmodified_inputs() throws Exception {
+        when(contractDefinition.getComplexInputs()).thenReturn(Collections.<ComplexInputDefinition> emptyList());
+        when(contractDefinition.getSimpleInputs()).thenReturn(Collections.<SimpleInputDefinition> emptyList());
+        final Map<String, Serializable> input = new HashMap<String, Serializable>();
+        input.put("input1", "value1");
+        input.put("input2", "value2");
+
+        final Map<String, Serializable> processedInput = contractTypeConverter.getProcessedInput(contractDefinition, input);
+
+        assertThat(processedInput).isEqualTo(input);
+    }
+
+    @Test
+    public void getProcessedInputs_with_simple_input_should_return_processed_input() throws Exception {
+        when(contractDefinition.getComplexInputs()).thenReturn(Collections.<ComplexInputDefinition> emptyList());
+        final List<SimpleInputDefinition> simpleInputDefinition = generateSimpleInputDefinition();
+        when(contractDefinition.getSimpleInputs()).thenReturn(simpleInputDefinition);
+        final Map<String, Serializable> input = generateInputMap();
+
+        final Map<String, Serializable> processedInput = contractTypeConverter.getProcessedInput(contractDefinition, input);
+
+        assertThat(processedInput).containsOnly(entry("inputText", "text"), entry("inputBoolean", true), entry("inputDate", new Date(0L)),
+                entry("inputInteger", 125686181L), entry("inputDecimal", new Double(12.8)));
+    }
+
+    @Test
+    public void getProcessedInputs_with_complex_input_should_return_processed_input() throws Exception {
+        final List<ComplexInputDefinition> complexInputDefinition = generateComplexInputDefinition();
+        when(contractDefinition.getComplexInputs()).thenReturn(complexInputDefinition);
+        when(contractDefinition.getSimpleInputs()).thenReturn(Collections.<SimpleInputDefinition> emptyList());
+        final Map<String, Serializable> input = new HashMap<String, Serializable>();
+        final Map<String, Serializable> complexInput = generateInputMap();
+        input.put("inputComplex", (Serializable) complexInput);
+
+        final Map<String, Serializable> processedInput = contractTypeConverter.getProcessedInput(contractDefinition, input);
+        assertThat(processedInput).containsKey("inputComplex");
+        final Map<String, Serializable> processedComplexInput = (Map<String, Serializable>) processedInput.get("inputComplex");
+        assertThat(processedComplexInput).containsOnly(entry("inputText", "text"), entry("inputBoolean", true), entry("inputDate", new Date(0L)),
+                entry("inputInteger", 125686181L), entry("inputDecimal", new Double(12.8)));
+    }
+
+    @Test
+    public void getProcessedInputs_with_multiple_complex_input_should_return_processed_input() throws Exception {
+        final List<ComplexInputDefinition> complexInputDefinition = generateComplexInputDefinition();
+        when(contractDefinition.getComplexInputs()).thenReturn(complexInputDefinition);
+        when(contractDefinition.getSimpleInputs()).thenReturn(Collections.<SimpleInputDefinition> emptyList());
+        final Map<String, Serializable> input = new HashMap<String, Serializable>();
+        final Map<String, Serializable> complexInput = generateInputMap();
+        final List<Serializable> multipleComplexInput = new ArrayList<Serializable>();
+        multipleComplexInput.add((Serializable) complexInput);
+        multipleComplexInput.add((Serializable) complexInput);
+        input.put("inputComplex", (Serializable) multipleComplexInput);
+
+        final Map<String, Serializable> processedInput = contractTypeConverter.getProcessedInput(contractDefinition, input);
+        assertThat(processedInput).containsKey("inputComplex");
+        final List<Serializable> processedMultipleComplexInput = (List<Serializable>) processedInput.get("inputComplex");
+        assertThat(processedMultipleComplexInput).hasSize(2);
+        for (final Serializable processedComplexInput : processedMultipleComplexInput) {
+            final Map<String, Serializable> processedComplexInputMap = (Map<String, Serializable>) processedComplexInput;
+            assertThat(processedComplexInputMap).containsOnly(entry("inputText", "text"), entry("inputBoolean", true), entry("inputDate", new Date(0L)),
+                    entry("inputInteger", 125686181L), entry("inputDecimal", new Double(12.8)));
+        }
+    }
+
+    private Map<String, Serializable> generateInputMap() {
+        final Map<String, Serializable> inputMap = new HashMap<String, Serializable>();
+        inputMap.put("inputText", "text");
+        inputMap.put("inputBoolean", "true");
+        inputMap.put("inputDate", "1970-01-01T01:00:00.000Z");
+        inputMap.put("inputInteger", 125686181);
+        inputMap.put("inputDecimal", "12.8");
+        return inputMap;
+    }
+
+    private List<SimpleInputDefinition> generateSimpleInputDefinition() {
+        final List<SimpleInputDefinition> simpleInputDefinitions = new ArrayList<SimpleInputDefinition>();
+        final SimpleInputDefinition textInputDefinition = mock(SimpleInputDefinition.class);
+        when(textInputDefinition.getType()).thenReturn(Type.TEXT);
+        when(textInputDefinition.getName()).thenReturn("inputText");
+        simpleInputDefinitions.add(textInputDefinition);
+        final SimpleInputDefinition booleanInputDefinition = mock(SimpleInputDefinition.class);
+        when(booleanInputDefinition.getType()).thenReturn(Type.BOOLEAN);
+        when(booleanInputDefinition.getName()).thenReturn("inputBoolean");
+        simpleInputDefinitions.add(booleanInputDefinition);
+        final SimpleInputDefinition dateInputDefinition = mock(SimpleInputDefinition.class);
+        when(dateInputDefinition.getType()).thenReturn(Type.DATE);
+        when(dateInputDefinition.getName()).thenReturn("inputDate");
+        simpleInputDefinitions.add(dateInputDefinition);
+        final SimpleInputDefinition integerInputDefinition = mock(SimpleInputDefinition.class);
+        when(integerInputDefinition.getType()).thenReturn(Type.INTEGER);
+        when(integerInputDefinition.getName()).thenReturn("inputInteger");
+        simpleInputDefinitions.add(integerInputDefinition);
+        final SimpleInputDefinition decimalInputDefinition = mock(SimpleInputDefinition.class);
+        when(decimalInputDefinition.getType()).thenReturn(Type.DECIMAL);
+        when(decimalInputDefinition.getName()).thenReturn("inputDecimal");
+        simpleInputDefinitions.add(decimalInputDefinition);
+        return simpleInputDefinitions;
+    }
+
+    private List<ComplexInputDefinition> generateComplexInputDefinition() {
+        final List<ComplexInputDefinition> complexInputDefinitions = new ArrayList<ComplexInputDefinition>();
+        final ComplexInputDefinition complexInputDefinition = mock(ComplexInputDefinition.class);
+        when(complexInputDefinition.getName()).thenReturn("inputComplex");
+        final List<SimpleInputDefinition> simpleInputDefinitions = generateSimpleInputDefinition();
+        when(complexInputDefinition.getSimpleInputs()).thenReturn(simpleInputDefinitions);
+        complexInputDefinitions.add(complexInputDefinition);
+        return complexInputDefinitions;
+    }
+}

--- a/server/src/test/java/org/bonitasoft/web/rest/server/api/bpm/flownode/UserTaskExecutionResourceTest.java
+++ b/server/src/test/java/org/bonitasoft/web/rest/server/api/bpm/flownode/UserTaskExecutionResourceTest.java
@@ -24,9 +24,11 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +36,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.bonitasoft.engine.api.ProcessAPI;
+import org.bonitasoft.engine.bpm.contract.ComplexInputDefinition;
+import org.bonitasoft.engine.bpm.contract.ContractDefinition;
 import org.bonitasoft.engine.bpm.contract.ContractViolationException;
+import org.bonitasoft.engine.bpm.contract.SimpleInputDefinition;
 import org.bonitasoft.engine.bpm.flownode.FlowNodeExecutionException;
 import org.bonitasoft.engine.bpm.flownode.UserTaskNotFoundException;
 import org.bonitasoft.engine.bpm.process.ProcessActivationException;
@@ -69,9 +74,14 @@ public class UserTaskExecutionResourceTest extends RestletTest {
     @Mock
     private Response response;
 
+    @Mock
+    private ContractDefinition contractDefinition;
+
     @Before
     public void initializeMocks() {
         userTaskExecutionResource = spy(new UserTaskExecutionResource(processAPI));
+        when(contractDefinition.getComplexInputs()).thenReturn(Collections.<ComplexInputDefinition> emptyList());
+        when(contractDefinition.getSimpleInputs()).thenReturn(Collections.<SimpleInputDefinition> emptyList());
     }
 
     @Override
@@ -96,16 +106,18 @@ public class UserTaskExecutionResourceTest extends RestletTest {
     @Test
     public void should_execute_a_task_with_given_inputs() throws Exception {
         final Map<String, Serializable> expectedComplexInput = aComplexInput();
+        when(processAPI.getUserTaskContract(2)).thenReturn(contractDefinition);
 
         final Response response = request("/bpm/userTask/2/execution").post(VALID_COMPLEX_POST_BODY);
 
         assertThat(response).hasStatus(Status.SUCCESS_NO_CONTENT);
         verify(processAPI).executeUserTask(2L, expectedComplexInput);
     }
-    
+
     @Test
     public void should_execute_a_task_with_given_inputs_for_a_specific_user() throws Exception {
         final Map<String, Serializable> expectedComplexInput = aComplexInput();
+        when(processAPI.getUserTaskContract(2)).thenReturn(contractDefinition);
 
         final Response response = request("/bpm/userTask/2/execution?user=1").post(VALID_COMPLEX_POST_BODY);
 
@@ -116,6 +128,7 @@ public class UserTaskExecutionResourceTest extends RestletTest {
 
     @Test
     public void should_respond_400_Bad_request_when_contract_is_not_validated_when_executing_a_task() throws Exception {
+        when(processAPI.getUserTaskContract(2)).thenReturn(contractDefinition);
         doThrow(new ContractViolationException("aMessage", asList("first explanation", "second explanation")))
                 .when(processAPI).executeUserTask(anyLong(), anyMapOf(String.class, Serializable.class));
 
@@ -146,6 +159,7 @@ public class UserTaskExecutionResourceTest extends RestletTest {
 
     @Test
     public void should_respond_404_Not_found_when_task_is_not_found_when_trying_to_execute_it() throws Exception {
+        when(processAPI.getUserTaskContract(2)).thenReturn(contractDefinition);
         doThrow(new UserTaskNotFoundException("task not found")).when(processAPI)
                 .executeUserTask(anyLong(), anyMapOf(String.class, Serializable.class));
 
@@ -162,6 +176,7 @@ public class UserTaskExecutionResourceTest extends RestletTest {
         final List<String> explanations = Arrays.asList("explanation1", "explanation2");
         doThrow(new ContractViolationException(message, explanations)).when(processAPI)
                 .executeUserTask(anyLong(), anyMapOf(String.class, Serializable.class));
+        when(processAPI.getUserTaskContract(1L)).thenReturn(contractDefinition);
         doReturn(logger).when(userTaskExecutionResource).getLogger();
         doReturn(1L).when(userTaskExecutionResource).getTaskIdParameter();
         doReturn(true).when(logger).isLoggable(Level.INFO);

--- a/server/src/test/java/org/bonitasoft/web/rest/server/api/bpm/process/ProcessInstantiationResourceTest.java
+++ b/server/src/test/java/org/bonitasoft/web/rest/server/api/bpm/process/ProcessInstantiationResourceTest.java
@@ -1,13 +1,20 @@
 package org.bonitasoft.web.rest.server.api.bpm.process;
 
-import static java.util.Arrays.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.bonitasoft.web.rest.server.utils.ResponseAssert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bonitasoft.web.rest.server.utils.ResponseAssert.assertThat;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,8 +22,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.bonitasoft.engine.api.ProcessAPI;
+import org.bonitasoft.engine.bpm.contract.ComplexInputDefinition;
+import org.bonitasoft.engine.bpm.contract.ContractDefinition;
 import org.bonitasoft.engine.bpm.contract.ContractViolationException;
-import org.bonitasoft.engine.bpm.process.ProcessActivationException;
+import org.bonitasoft.engine.bpm.contract.SimpleInputDefinition;
 import org.bonitasoft.engine.bpm.process.ProcessDefinitionNotFoundException;
 import org.bonitasoft.engine.bpm.process.ProcessExecutionException;
 import org.bonitasoft.engine.bpm.process.impl.internal.ProcessInstanceImpl;
@@ -47,24 +56,29 @@ public class ProcessInstantiationResourceTest extends RestletTest {
     private static final String VALID_POST_BODY = "{ \"key\": \"value\", \"key2\": \"value2\" }";
 
     @Mock
-    private ProcessAPI processAPI;
+    ProcessAPI processAPI;
 
     @Mock
-    private Logger logger;
+    Logger logger;
 
     ProcessInstantiationResource processInstanciationResource;
 
     @Mock
-    private Response response;
+    Response response;
 
-    @Override
-    protected ServerResource configureResource() {
-        return new ProcessInstantiationResource(processAPI);
-    }
+    @Mock
+    ContractDefinition contractDefinition;
 
     @Before
     public void initializeMocks() {
         processInstanciationResource = spy(new ProcessInstantiationResource(processAPI));
+        when(contractDefinition.getComplexInputs()).thenReturn(Collections.<ComplexInputDefinition> emptyList());
+        when(contractDefinition.getSimpleInputs()).thenReturn(Collections.<SimpleInputDefinition> emptyList());
+    }
+
+    @Override
+    protected ServerResource configureResource() {
+        return new ProcessInstantiationResource(processAPI);
     }
 
     private Map<String, Serializable> aComplexInput() {
@@ -85,6 +99,8 @@ public class ProcessInstantiationResourceTest extends RestletTest {
     public void should_instanciate_a_process_with_given_inputs() throws Exception {
         final Map<String, Serializable> expectedComplexInput = aComplexInput();
         when(processAPI.startProcessWithInputs(PROCESS_DEFINITION_ID, expectedComplexInput)).thenReturn(new ProcessInstanceImpl("complexProcessInstance"));
+        when(processAPI.getProcessContract(PROCESS_DEFINITION_ID)).thenReturn(contractDefinition);
+
         final Response response = request(URL_API_PROCESS_INSTANCIATION_TEST).post(VALID_COMPLEX_POST_BODY);
 
         assertThat(response).hasStatus(Status.SUCCESS_OK);
@@ -104,6 +120,8 @@ public class ProcessInstantiationResourceTest extends RestletTest {
     public void should_instanciate_a_process_with_given_inputs_for_a_specific_user() throws Exception {
         final Map<String, Serializable> expectedComplexInput = aComplexInput();
         when(processAPI.startProcessWithInputs(1L, PROCESS_DEFINITION_ID, expectedComplexInput)).thenReturn(new ProcessInstanceImpl("complexProcessInstance"));
+        when(processAPI.getProcessContract(PROCESS_DEFINITION_ID)).thenReturn(contractDefinition);
+
         final Response response = request(URL_API_PROCESS_INSTANCIATION_TEST_WITH_USER).post(VALID_COMPLEX_POST_BODY);
 
         assertThat(response).hasStatus(Status.SUCCESS_OK);
@@ -123,6 +141,7 @@ public class ProcessInstantiationResourceTest extends RestletTest {
     public void should_respond_400_Bad_request_when_contract_is_not_validated_when_instanciate_a_process() throws Exception {
         doThrow(new ContractViolationException("aMessage", asList("first explanation", "second explanation")))
         .when(processAPI).startProcessWithInputs(anyLong(), anyMapOf(String.class, Serializable.class));
+        when(processAPI.getProcessContract(PROCESS_DEFINITION_ID)).thenReturn(contractDefinition);
 
         final Response response = request(URL_API_PROCESS_INSTANCIATION_TEST).post(VALID_POST_BODY);
 
@@ -153,6 +172,7 @@ public class ProcessInstantiationResourceTest extends RestletTest {
     public void should_respond_404_Not_found_when_task_is_not_found_when_trying_to_execute_it() throws Exception {
         doThrow(new ProcessDefinitionNotFoundException("process not found")).when(processAPI)
         .startProcessWithInputs(anyLong(), anyMapOf(String.class, Serializable.class));
+        when(processAPI.getProcessContract(PROCESS_DEFINITION_ID)).thenReturn(contractDefinition);
 
         final Response response = request(URL_API_PROCESS_INSTANCIATION_TEST).post(VALID_POST_BODY);
 
@@ -160,16 +180,15 @@ public class ProcessInstantiationResourceTest extends RestletTest {
     }
 
     @Test
-    public void should_contract_violation_exception_log_explanations_when_logger_is_info() throws ProcessDefinitionNotFoundException,
-    ProcessActivationException,
-    ProcessExecutionException, ContractViolationException {
+    public void should_contract_violation_exception_log_explanations_when_logger_is_info() throws Exception {
         // given
         final String message = "contract violation !!!!";
         final List<String> explanations = Arrays.asList("explanation1", "explanation2");
         doThrow(new ContractViolationException(message, explanations)).when(processAPI)
         .startProcessWithInputs(anyLong(), anyMapOf(String.class, Serializable.class));
         doReturn(logger).when(processInstanciationResource).getLogger();
-        doReturn(1L).when(processInstanciationResource).getProcessDefinitionIdParameter();
+        doReturn(Long.toString(PROCESS_DEFINITION_ID)).when(processInstanciationResource).getAttribute(ProcessInstantiationResource.PROCESS_DEFINITION_ID);
+        doReturn(contractDefinition).when(processAPI).getProcessContract(PROCESS_DEFINITION_ID);
         doReturn(true).when(logger).isLoggable(Level.INFO);
         doReturn(response).when(processInstanciationResource).getResponse();
         final Map<String, Serializable> inputs = new HashMap<>();


### PR DESCRIPTION
Fixing support for numeric, dates, boolean and multiples when instantiating a contract of executing a task