### PR TITLE
BS-13249 IE loses the focus of the input fields

### DIFF
--- a/forms/forms-view/src/main/java/org/bonitasoft/forms/client/view/common/DOMUtils.java
+++ b/forms/forms-view/src/main/java/org/bonitasoft/forms/client/view/common/DOMUtils.java
@@ -524,7 +524,7 @@ public class DOMUtils {
 
     /**
      * Override a checkbox or radiobuton behavior after it is checked or unchecked
-     * 
+     *
      * @param checbox
      * @param checked
      */
@@ -612,7 +612,7 @@ public class DOMUtils {
         theElement = DOM.getElementById("loading");
         if (theElement != null) {
             theElement.getStyle().setProperty("display", "table");
-            theElement.getStyle().setProperty("zIndex", "999");
+
         }
     }
 


### PR DESCRIPTION
 IE loses the focus of the input fields when a click is done on the load image on the screen during loading a Task.