### PR TITLE
uniformize npm dependencies declaration in custom pages

### DIFF
--- a/custom-pages/case-autogenerated-overview/package.json
+++ b/custom-pages/case-autogenerated-overview/package.json
@@ -14,10 +14,7 @@
   "author": "",
   "license": "GPL",
   "devDependencies": {
-    "angular": "1.3.15",
-    "angular-bootstrap": "^0.12.0",
     "angular-mocks": "~1.3",
-    "bootstrap": "^3.3.2",
     "connect-modrewrite": "^0.7.9",
     "gulp": "^3.8.11",
     "gulp-bower": "0.0.6",
@@ -44,6 +41,8 @@
     "run-sequence": "^1.0.1"
   },
   "dependencies": {
+    "angular": "1.3.15",
+    "angular-bootstrap": "^0.12.0",
     "bootstrap": "^3.3.2",
     "angular-resource": "1.3.0",
     "angular-timeline": "rpocklin/angular-timeline#v1.2.0"

--- a/custom-pages/process-autogenerated-form/package.json
+++ b/custom-pages/process-autogenerated-form/package.json
@@ -14,9 +14,7 @@
   "author": "",
   "license": "GPL",
   "devDependencies": {
-    "angular": "1.3.15",
     "angular-mocks": "~1.3",
-    "bootstrap": "^3.3.2",
     "connect-modrewrite": "^0.7.9",
     "gulp": "^3.8.11",
     "gulp-angular-gettext": "^2.1.0",
@@ -44,10 +42,12 @@
     "run-sequence": "^1.0.1"
   },
   "dependencies": {
+    "angular": "1.3.15",
     "angular-resource": "1.3.0", 
-    "ngUpload": "git://github.com/twilson63/ngUpload#v0.5.14",
     "angular-bootstrap": "^0.12.0",
     "angular-gettext": "~0.4.0",
-    "angular-cookies": "~1.3.4"
+    "angular-cookies": "~1.3.4",
+    "bootstrap": "^3.3.2",
+    "ngUpload": "twilson63/ngUpload#v0.5.14"
   }
 }

--- a/custom-pages/step-autogenerated-form/package.json
+++ b/custom-pages/step-autogenerated-form/package.json
@@ -14,9 +14,7 @@
   "author": "",
   "license": "GPL",
   "devDependencies": {
-    "angular": "1.3.15",
     "angular-mocks": "~1.3",
-    "bootstrap": "^3.3.2",
     "connect-modrewrite": "^0.7.9",
     "gulp": "^3.8.11",
     "gulp-angular-gettext": "^2.1.0",
@@ -44,10 +42,12 @@
     "run-sequence": "^1.0.1"
   },
   "dependencies": {
+    "angular": "1.3.15",
     "angular-bootstrap": "^0.12.0",
     "angular-cookies": "~1.3.4",
     "angular-gettext": "~0.4.0",
     "angular-resource": "1.3.0",
-    "ngUpload": "git://github.com/twilson63/ngUpload#v0.5.14"
+    "bootstrap": "^3.3.2",
+    "ngUpload": "twilson63/ngUpload#v0.5.14"
   }
 }


### PR DESCRIPTION
- Remove git://github.com/ prefixes
- Remove duplication form DevDependencies and Dependencies
- Move used dep from devdep to dep