### PR TITLE
BS-14501 add all groovy files in classpath

### DIFF
--- a/server/src/test/resources/ARootPageFolder/AbstractIndex.groovy
+++ b/server/src/test/resources/ARootPageFolder/AbstractIndex.groovy
@@ -1,0 +1,7 @@
+public class AbstractIndex {
+
+    public String name(){
+        return "name";
+    }
+
+}

--- a/server/src/test/resources/ARootPageFolder/Index.groovy
+++ b/server/src/test/resources/ARootPageFolder/Index.groovy
@@ -1,0 +1,9 @@
+
+public class Index extends AbstractIndex {
+
+    public void doGet() {
+
+        
+    }
+
+}

--- a/server/src/test/resources/ARootPageFolder/org/company/test/Util.groovy
+++ b/server/src/test/resources/ARootPageFolder/org/company/test/Util.groovy
@@ -1,0 +1,9 @@
+package org.company.test;
+
+public class Util {
+
+    public static String name(){
+        return "My Name";
+    }
+
+}

--- a/server/src/test/resources/ARootPageFolder/org/company/test/config.properties
+++ b/server/src/test/resources/ARootPageFolder/org/company/test/config.properties
@@ -1,0 +1,1 @@
+aProperty=Value


### PR DESCRIPTION
Enables the possibilty to use a standard project hierachy for Rest api extensions:
Many source files and resources in packages (not only default package).

It doesn't break the runtime mechanism (with the Index.groovy).
Some integration test should be performed to check behavior when having jar dependencies.