### PR TITLE
update jackson version to 2.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <bonita.home.test>${project.build.directory}/bonita-home</bonita.home.test>
         <urlrewrite.version>4.0.3</urlrewrite.version>
         <restlet-version>2.3.1</restlet-version>
+        <jackson.version>2.4.4</jackson.version>
         <!-- The Sonar Jacoco Listener for JUnit to extract coverage details per test -->
         <sonar-jacoco-listeners.version>1.4</sonar-jacoco-listeners.version>
     </properties>

--- a/security-scripts/pom.xml
+++ b/security-scripts/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.2.3</version>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.2.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>


### PR DESCRIPTION
currently the version is not the same as the version used by restlet,
put it to 2.4.4
in addition the engine use also the 2.4.4 and need version >= 2.4.1 to
use the clearCache on TypeFactory to fix classloader leak

depends on https://github.com/bonitasoft/bonita-engine/pull/223