### PR TITLE
BS-14712, allow query parameters to contain values with comma character

### DIFF
--- a/server/src/main/java/org/bonitasoft/web/rest/server/api/resource/CommonResource.java
+++ b/server/src/main/java/org/bonitasoft/web/rest/server/api/resource/CommonResource.java
@@ -13,7 +13,20 @@
  **/
 package org.bonitasoft.web.rest.server.api.resource;
 
-import com.fasterxml.jackson.core.JsonParseException;
+import java.io.FileNotFoundException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 import org.bonitasoft.engine.bpm.contract.ContractViolationException;
 import org.bonitasoft.engine.exception.NotFoundException;
 import org.bonitasoft.engine.search.SearchOptions;
@@ -34,18 +47,7 @@ import org.restlet.resource.ResourceException;
 import org.restlet.resource.ServerResource;
 import org.restlet.util.Series;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-import java.io.FileNotFoundException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import com.fasterxml.jackson.core.JsonParseException;
 
 /**
  * @author Emmanuel Duchastenier
@@ -96,7 +98,7 @@ public class CommonResource extends ServerResource {
         if (parameters == null) {
             return null;
         }
-        final Map<String, String> results = new HashMap<String, String>();
+        final Map<String, String> results = new HashMap<>();
         for (final String parameter : parameters) {
             final String[] split = parameter.split("=");
             if (split.length < 2) {
@@ -151,21 +153,14 @@ public class CommonResource extends ServerResource {
     }
 
     /**
-     * Get a list of parameter values by name.
+     * Get a list of parameter values by name. If the parameter doesn't exist the result will be an empty list.
      *
      * @param name
      *        The name of the parameter (case sensitive).
-     * @return The values of a parameter as a list of String, or <code>null</code> if the parameter doesn't exist.
+     * @return The values of a parameter as a list of String.
      */
     public List<String> getParameterAsList(final String name) {
-        final String values = getQuery().getValues(name);
-        if (values != null) {
-            final String[] parameterValues = values.split(",");
-            if (parameterValues != null && parameterValues.length > 0) {
-                return Arrays.asList(parameterValues);
-            }
-        }
-        return null;
+        return Arrays.asList(getQuery().getValuesArray(name));
     }
 
     public SearchOptions buildSearchOptions() {
@@ -193,15 +188,13 @@ public class CommonResource extends ServerResource {
                 LOGGER.log(Level.FINE, "***" + message);
             }
             getResponse().setStatus(Status.CLIENT_ERROR_BAD_REQUEST);
-        }
-        else if (t instanceof FileNotFoundException) {
+        } else if (t instanceof FileNotFoundException) {
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "***" + message);
             }
             getResponse().setStatus(Status.CLIENT_ERROR_NOT_FOUND);
             errorMessage.setMessage("File Not Found");
-        }
-        else if (t instanceof NotFoundException) {
+        } else if (t instanceof NotFoundException) {
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "***" + message);
             }
@@ -236,24 +229,24 @@ public class CommonResource extends ServerResource {
         return convertToLong(value);
     }
 
-	private Long convertToLong(final String value) {
-		try {
+    private Long convertToLong(final String value) {
+        try {
             return Long.parseLong(value);
         } catch (final NumberFormatException e) {
             throw new IllegalArgumentException("[ " + value + " ] must be a number");
         }
-	}
+    }
 
     public List<Long> getParameterAsLongList(final String parameterName) {
         final String values = getQuery().getValues(parameterName);
         if (values != null) {
             final String[] parameterValues = values.split(",");
             if (parameterValues != null && parameterValues.length > 0) {
-            	final List<Long> longValues = new ArrayList<>();
-            	for (String parameterValue : parameterValues) {
-					longValues.add(convertToLong(parameterValue));
-				}
-            	return longValues;
+                final List<Long> longValues = new ArrayList<>();
+                for (String parameterValue : parameterValues) {
+                    longValues.add(convertToLong(parameterValue));
+                }
+                return longValues;
             }
         }
         return null;

--- a/server/src/test/java/org/bonitasoft/web/rest/server/api/resource/CommonResourceTest.java
+++ b/server/src/test/java/org/bonitasoft/web/rest/server/api/resource/CommonResourceTest.java
@@ -3,6 +3,7 @@ package org.bonitasoft.web.rest.server.api.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.bonitasoft.web.rest.server.utils.ResponseAssert.assertThat;
 import static org.bonitasoft.web.rest.server.utils.RestletAppBuilder.aTestApp;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyObject;
@@ -30,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.restlet.Application;
 import org.restlet.Response;
+import org.restlet.data.Form;
 import org.restlet.data.Status;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -155,7 +157,7 @@ public class CommonResourceTest extends RestletTest {
     @Test
     public void parseFilterShouldBuildMapEvenIfNoValueForParam() throws Exception {
         // given:
-        final List<String> filters = new ArrayList<String>(2);
+        final List<String> filters = new ArrayList<>(2);
         filters.add("nomatchingvalue=");
 
         // when:
@@ -260,6 +262,34 @@ public class CommonResourceTest extends RestletTest {
 
         assertThat(response).hasStatus(Status.CLIENT_ERROR_BAD_REQUEST);
         assertThat(response).hasJsonEntityEqualTo("{\"exception\":\"class java.lang.IllegalArgumentException\",\"message\":\"an error message\"}'");
+    }
+
+    @Test
+    public void getParametersAsList_should_support_value_with_comma() throws Exception {
+        //given
+        CommonResource resource = spy(new CommonResource());
+        Form form = new Form("f=a=b&f=c=d,e");
+        given(resource.getQuery()).willReturn(form);
+
+        //when
+        List<String> parametersValues = resource.getParameterAsList("f");
+
+        //then
+        assertThat(parametersValues).containsExactly("a=b", "c=d,e");
+    }
+
+    @Test
+    public void getParametersAsList_should_return_emptyList_when_parameter_does_not_exist() throws Exception {
+        //given
+        CommonResource resource = spy(new CommonResource());
+        Form form = new Form("f=a=b&f=c=d,e");
+        given(resource.getQuery()).willReturn(form);
+
+        //when
+        List<String> parametersValues = resource.getParameterAsList("anyAbsent");
+
+        //then
+        assertThat(parametersValues).isEmpty();
     }
 
 }


### PR DESCRIPTION
Instead of using the method getValues that concatenates all values into a single String, use the method getValuesArray that returns an array of values