### PR TITLE
BS-14661 - disable overview button

### DIFF
--- a/portal/src/main/java/org/bonitasoft/console/client/user/cases/view/AbstractOverviewFormMappingRequester.java
+++ b/portal/src/main/java/org/bonitasoft/console/client/user/cases/view/AbstractOverviewFormMappingRequester.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.bonitasoft.console.client.user.cases.view;
 
 import java.util.Map;
@@ -15,21 +29,7 @@ import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONParser;
 import com.google.gwt.json.client.JSONValue;
 
-/**
- * Copyright (C) 2015 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2.0 of the License, or
- * (at your option) any later version.
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
-public abstract class OverviewFormMappingRequester {
+public abstract class AbstractOverviewFormMappingRequester {
 
     static final String ATTRIBUTE_FORM_MAPPING_TYPE = "type";
 
@@ -70,24 +70,24 @@ public abstract class OverviewFormMappingRequester {
                 ViewController.closePopup();
                 if (formMapping.containsKey(ATTRIBUTE_FORM_MAPPING_TARGET)
                         && NONE_FORM_MAPPING_TARGET.equals(formMapping.get(ATTRIBUTE_FORM_MAPPING_TARGET).isString().stringValue())) {
-                    onNoMappingFound();
+                    onMappingNotFound();
                 } else {
                     onMappingFound();
                 }
             } else {
                 GWT.log("There is no overview mapping for process " + processId);
-                onNoMappingFound();
+                onMappingNotFound();
             }
         }
 
         @Override
         public void onError(final String message, final Integer errorCode) {
-            GWT.log("Error while getting the overview mapping for process  " + processId);
+            GWT.log("Error while getting the overview mapping for process " + processId);
             super.onError(message, errorCode);
         }
     }
 
     public abstract void onMappingFound();
 
-    public abstract void onNoMappingFound();
+    public abstract void onMappingNotFound();
 }

--- a/portal/src/main/java/org/bonitasoft/console/client/user/cases/view/DisplayCaseFormPage.java
+++ b/portal/src/main/java/org/bonitasoft/console/client/user/cases/view/DisplayCaseFormPage.java
@@ -32,6 +32,7 @@ import org.bonitasoft.web.toolkit.client.common.i18n.AbstractI18n;
 import org.bonitasoft.web.toolkit.client.common.texttemplate.Arg;
 import org.bonitasoft.web.toolkit.client.common.url.UrlUtil;
 import org.bonitasoft.web.toolkit.client.ui.Page;
+import org.bonitasoft.web.toolkit.client.ui.component.Text;
 import org.bonitasoft.web.toolkit.client.ui.component.button.ButtonBack;
 import org.bonitasoft.web.toolkit.client.ui.component.containers.Container;
 import org.bonitasoft.web.toolkit.client.ui.component.core.AbstractComponent;
@@ -82,6 +83,25 @@ public class DisplayCaseFormPage extends Page {
         final IFrameView view = new IFrameView(getCaseOverviewUrl());
         addBody(new UiComponent(view));
         view.addTool(new ButtonBack());
+        //Check form mapping to ensure there is an overview form to display
+        checkMapping();
+    }
+
+    private void checkMapping() {
+        final String processId = this.getParameter(CaseItem.ATTRIBUTE_PROCESS_ID);
+        final OverviewFormMappingRequester overviewFormMappingRequester = new OverviewFormMappingRequester() {
+
+            @Override
+            public void onNoMappingFound() {
+                addHeader(new Text(_("No overview form has been defined for this process")));
+            }
+
+            @Override
+            public void onMappingFound() {
+                //do nothing
+            }
+        };
+        overviewFormMappingRequester.searchFormMappingForInstance(processId);
     }
 
     private String getCaseOverviewUrl() {

--- a/portal/src/main/java/org/bonitasoft/console/client/user/cases/view/DisplayCaseFormPage.java
+++ b/portal/src/main/java/org/bonitasoft/console/client/user/cases/view/DisplayCaseFormPage.java
@@ -89,10 +89,10 @@ public class DisplayCaseFormPage extends Page {
 
     private void checkMapping() {
         final String processId = this.getParameter(CaseItem.ATTRIBUTE_PROCESS_ID);
-        final OverviewFormMappingRequester overviewFormMappingRequester = new OverviewFormMappingRequester() {
+        final AbstractOverviewFormMappingRequester overviewFormMappingRequester = new AbstractOverviewFormMappingRequester() {
 
             @Override
-            public void onNoMappingFound() {
+            public void onMappingNotFound() {
                 addHeader(new Text(_("No overview form has been defined for this process")));
             }
 

--- a/portal/src/main/java/org/bonitasoft/console/client/user/cases/view/OverviewFormMappingRequester.java
+++ b/portal/src/main/java/org/bonitasoft/console/client/user/cases/view/OverviewFormMappingRequester.java
@@ -1,0 +1,93 @@
+package org.bonitasoft.console.client.user.cases.view;
+
+import java.util.Map;
+
+import org.bonitasoft.web.rest.model.portal.page.PageItem;
+import org.bonitasoft.web.toolkit.client.ViewController;
+import org.bonitasoft.web.toolkit.client.data.api.callback.APICallback;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.http.client.RequestBuilder;
+import com.google.gwt.http.client.RequestException;
+import com.google.gwt.http.client.URL;
+import com.google.gwt.json.client.JSONArray;
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONParser;
+import com.google.gwt.json.client.JSONValue;
+
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+public abstract class OverviewFormMappingRequester {
+
+    static final String ATTRIBUTE_FORM_MAPPING_TYPE = "type";
+
+    static final String PROCESS_OVERVIEW_FORM_MAPPING_TYPE = "PROCESS_OVERVIEW";
+
+    static final String ATTRIBUTE_FORM_MAPPING_TARGET = "target";
+
+    static final String NONE_FORM_MAPPING_TARGET = "NONE";
+
+    public void searchFormMappingForInstance(final String processId) {
+        RequestBuilder requestBuilder;
+        final String processIdFilter = URL.encodeQueryString(PageItem.ATTRIBUTE_PROCESS_ID + "=" + processId);
+        final String mappingTypeFilter = URL.encodeQueryString(ATTRIBUTE_FORM_MAPPING_TYPE + "=" + PROCESS_OVERVIEW_FORM_MAPPING_TYPE);
+        requestBuilder = new RequestBuilder(RequestBuilder.GET, "../API/form/mapping?c=10&p=0&f=" + processIdFilter + "&f=" + mappingTypeFilter);
+        requestBuilder.setCallback(new FormMappingCallback(processId));
+        try {
+            requestBuilder.send();
+        } catch (final RequestException e) {
+            GWT.log("Error while creating the from mapping request", e);
+        }
+    }
+
+    protected class FormMappingCallback extends APICallback {
+
+        private final String processId;
+
+        public FormMappingCallback(final String processId) {
+            this.processId = processId;
+        }
+
+        @Override
+        public void onSuccess(final int httpStatusCode, final String response, final Map<String, String> headers) {
+            final JSONValue root = JSONParser.parseLenient(response);
+            final JSONArray formMappings = root.isArray();
+            if (formMappings.size() == 1) {
+                final JSONValue formMappingValue = formMappings.get(0);
+                final JSONObject formMapping = formMappingValue.isObject();
+                ViewController.closePopup();
+                if (formMapping.containsKey(ATTRIBUTE_FORM_MAPPING_TARGET)
+                        && NONE_FORM_MAPPING_TARGET.equals(formMapping.get(ATTRIBUTE_FORM_MAPPING_TARGET).isString().stringValue())) {
+                    onNoMappingFound();
+                } else {
+                    onMappingFound();
+                }
+            } else {
+                GWT.log("There is no overview mapping for process " + processId);
+                onNoMappingFound();
+            }
+        }
+
+        @Override
+        public void onError(final String message, final Integer errorCode) {
+            GWT.log("Error while getting the overview mapping for process  " + processId);
+            super.onError(message, errorCode);
+        }
+    }
+
+    public abstract void onMappingFound();
+
+    public abstract void onNoMappingFound();
+}

--- a/portal/src/main/java/org/bonitasoft/console/client/user/cases/view/component/CaseOverviewButton.java
+++ b/portal/src/main/java/org/bonitasoft/console/client/user/cases/view/component/CaseOverviewButton.java
@@ -17,7 +17,7 @@ package org.bonitasoft.console.client.user.cases.view.component;
 import static org.bonitasoft.web.toolkit.client.common.i18n.AbstractI18n._;
 
 import org.bonitasoft.console.client.user.cases.view.DisplayCaseFormPage;
-import org.bonitasoft.console.client.user.cases.view.OverviewFormMappingRequester;
+import org.bonitasoft.console.client.user.cases.view.AbstractOverviewFormMappingRequester;
 import org.bonitasoft.web.rest.model.bpm.cases.CaseItem;
 import org.bonitasoft.web.toolkit.client.ui.JsId;
 import org.bonitasoft.web.toolkit.client.ui.action.ActionShowView;
@@ -28,10 +28,10 @@ public class CaseOverviewButton extends Button {
     public CaseOverviewButton(final CaseItem caseItem) {
         super("btn-overview", new JsId("btn-action"), _("Overview"), _("Display the case overview"), new ActionShowView(new DisplayCaseFormPage(caseItem)));
         //Check form mapping to ensure there is an overview form to display
-        final OverviewFormMappingRequester overviewFormMappingRequester = new OverviewFormMappingRequester() {
+        final AbstractOverviewFormMappingRequester overviewFormMappingRequester = new AbstractOverviewFormMappingRequester() {
 
             @Override
-            public void onNoMappingFound() {
+            public void onMappingNotFound() {
                 disableButton();
             }
 

--- a/portal/src/main/java/org/bonitasoft/console/client/user/cases/view/component/CaseOverviewButton.java
+++ b/portal/src/main/java/org/bonitasoft/console/client/user/cases/view/component/CaseOverviewButton.java
@@ -1,8 +1,23 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2.0 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.bonitasoft.console.client.user.cases.view.component;
 
 import static org.bonitasoft.web.toolkit.client.common.i18n.AbstractI18n._;
 
 import org.bonitasoft.console.client.user.cases.view.DisplayCaseFormPage;
+import org.bonitasoft.console.client.user.cases.view.OverviewFormMappingRequester;
 import org.bonitasoft.web.rest.model.bpm.cases.CaseItem;
 import org.bonitasoft.web.toolkit.client.ui.JsId;
 import org.bonitasoft.web.toolkit.client.ui.action.ActionShowView;
@@ -10,8 +25,29 @@ import org.bonitasoft.web.toolkit.client.ui.component.Button;
 
 public class CaseOverviewButton extends Button {
 
-    public CaseOverviewButton(final CaseItem aCase) {
-        super("btn-overview", new JsId("btn-action"), _("Overview"), _("Display the case form"), new ActionShowView(new DisplayCaseFormPage(aCase)));
+    public CaseOverviewButton(final CaseItem caseItem) {
+        super("btn-overview", new JsId("btn-action"), _("Overview"), _("Display the case overview"), new ActionShowView(new DisplayCaseFormPage(caseItem)));
+        //Check form mapping to ensure there is an overview form to display
+        final OverviewFormMappingRequester overviewFormMappingRequester = new OverviewFormMappingRequester() {
+
+            @Override
+            public void onNoMappingFound() {
+                disableButton();
+            }
+
+            @Override
+            public void onMappingFound() {
+                //do nothing
+            }
+        };
+        overviewFormMappingRequester.searchFormMappingForInstance(caseItem.getProcessId().toString());
+    }
+
+
+    protected void disableButton() {
+        //disable the button
+        setEnabled(false);
+        setTooltip(_("No overview form has been defined for this process"));
     }
 
 }

--- a/server/src/main/java/org/bonitasoft/console/common/server/page/PageServlet.java
+++ b/server/src/main/java/org/bonitasoft/console/common/server/page/PageServlet.java
@@ -126,11 +126,11 @@ public class PageServlet extends HttpServlet {
             } else if (pageReference.getPageId() != null) {
                 displayPageOrResource(request, response, apiSession, pageReference.getPageId(), resourcePath);
             } else {
-                if (LOGGER.isLoggable(Level.WARNING)) {
+                if (LOGGER.isLoggable(Level.FINE)) {
                     final String message = "Both URL and pageId are not set in the page mapping for " + mappingKey;
-                    LOGGER.log(Level.WARNING, message);
+                    LOGGER.log(Level.FINE, message);
                 }
-                response.sendError(HttpServletResponse.SC_NOT_FOUND, "Form mapping not found");
+                return;
             }
         } catch (final UnauthorizedAccessException e) {
             final String message = "User not Authorized";

--- a/server/src/test/java/org/bonitasoft/console/common/server/page/PageServletTest.java
+++ b/server/src/test/java/org/bonitasoft/console/common/server/page/PageServletTest.java
@@ -1,5 +1,6 @@
 package org.bonitasoft.console.common.server.page;
 
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -162,14 +163,14 @@ public class PageServletTest {
     }
 
     @Test
-    public void should_get_not_found_when_empty_mapping() throws Exception {
+    public void should_not_get_not_found_when_empty_mapping() throws Exception {
         when(hsRequest.getPathInfo()).thenReturn("/process/processName/processVersion/content/");
         final PageReference pageReference = new PageReference(null, null);
         doReturn(pageReference).when(pageMappingService).getPage(hsRequest, apiSession, "process/processName/processVersion", locale, true);
 
         pageServlet.service(hsRequest, hsResponse);
 
-        verify(hsResponse, times(1)).sendError(404, "Form mapping not found");
+        verify(hsResponse, never()).sendError(anyInt(), anyString());
     }
 
     @Test


### PR DESCRIPTION
Disable overview button in quick and more details pages in case there is no mapping for the overview. Also display a blank page instead of a 404 and a message above.