### PR TITLE
Add /API/formsDocumentImage url-pattern for formsDocumentImage servlet

### DIFF
--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -548,6 +548,7 @@
     <servlet-mapping>
         <servlet-name>formsDocumentImage</servlet-name>
         <url-pattern>/portal/formsDocumentImage</url-pattern>
+        <url-pattern>/API/formsDocumentImage</url-pattern>
     </servlet-mapping>
     <servlet-mapping>
         <servlet-name>loginService</servlet-name>


### PR DESCRIPTION
Allow to access to this servlet via ../API/API/formsDocumentImage in custom pages

Needed by https://github.com/bonitasoft/bonita-widget-contrib/pull/10