### PR TITLE
fix(BS-13689) On IE, Simple click is not working to upload a file

### DIFF
--- a/looknfeel/src/main/less/skin/bootstrap/portal/applications/import.less
+++ b/looknfeel/src/main/less/skin/bootstrap/portal/applications/import.less
@@ -33,6 +33,11 @@
 
 }
 
+// fixes BS-13689 on ie double click is needed to open browse box
+.isBrowser-ie .upload-field input {
+  font-size: 999px;
+}
+
 .upload-field-content {
   position: absolute;
   z-index: 10;


### PR DESCRIPTION
Added font-size to .upload-field input for ie only

Fixes [BS-13689](https://bonitasoft.atlassian.net/browse/BS-13689)