### PR TITLE
update jackson version to 2.4.4

### DIFF
--- a/security-scripts/pom.xml
+++ b/security-scripts/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.2.3</version>
+            <version>2.4.4</version>
         </dependency>
     </dependencies>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.2.3</version>
+            <version>2.4.4</version>
         </dependency>
         <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>


### PR DESCRIPTION
follow engine update of jackson to 2.4.4
2.2.3 has an issue that kept references to classloader
we choosed 2.4.4 because restlet use already this version