### PR TITLE
BS-14796 - fix modal task form close button

### DIFF
--- a/looknfeel/src/main/less/skin/bootstrap/portal/tasks/task-list.less
+++ b/looknfeel/src/main/less/skin/bootstrap/portal/tasks/task-list.less
@@ -464,6 +464,7 @@
 .Viewer-wrapper {
   position: relative;
   display: block;
+  clear: both;
 }
 .Viewer-overlay {
   background-color: rgba(255, 255, 255, .5);


### PR DESCRIPTION
BS-14796 - fix modal task form close button
The button cannot be clicked because it is unreachable due to its floating position.
This PR applies clear: both attribute to the modal content so that it get displayed below the button and not over it