### PR TITLE
BS-14834 - only display completed tasks

### DIFF
--- a/portal/src/main/java/org/bonitasoft/console/client/user/task/view/TasksListingPage.java
+++ b/portal/src/main/java/org/bonitasoft/console/client/user/task/view/TasksListingPage.java
@@ -167,6 +167,7 @@ public class TasksListingPage extends ItemListingPage<HumanTaskItem> implements 
     private ItemTable performedTasksItemTable() {
         return new ItemTable(Definitions.get(ArchivedHumanTaskDefinition.TOKEN))
                 .addHiddenFilter(HumanTaskItem.ATTRIBUTE_ASSIGNED_USER_ID, Session.getUserId())
+                .addHiddenFilter(HumanTaskItem.ATTRIBUTE_STATE, HumanTaskItem.VALUE_STATE_COMPLETED)
                 .addColumn(ArchivedHumanTaskItem.ATTRIBUTE_DISPLAY_NAME, _("Name"), true)
                 .addColumn(new DateAttributeReader(ArchivedHumanTaskItem.ATTRIBUTE_REACHED_STATE_DATE), _("Performed date"), true)
                 .addColumn(


### PR DESCRIPTION
Only display completed tasks in the user profile task list when the done task filter is selected (aborted tasks shouldn't be displayed)
Fixes [BS-14834](https://bonitasoft.atlassian.net/browse/BS-14834)