### PR TITLE
fix(BS-14894) Cannot view complete overiew page of case in IE

### DIFF
--- a/looknfeel/src/main/resources/BonitaConsole.html
+++ b/looknfeel/src/main/resources/BonitaConsole.html
@@ -15,6 +15,9 @@
 			<link rel="stylesheet" type="text/css" href="themeResource?theme=portal&location=bonita_ie8.css&v=${project.version}">
 		<![endif]-->
 		
+		<!--[if lte IE 11]>
+			<link rel="stylesheet" type="text/css" href="themeResource?theme=portal&location=bonita_ie.css&v=${project.version}">
+		<![endif]-->
 
 		<!-- Load JQuery -->
  		<script type="text/javascript" src="scripts/jquery/jquery-1.6.4.js?v=${project.version}"></script>

--- a/looknfeel/src/main/resources/bonita_ie.css
+++ b/looknfeel/src/main/resources/bonita_ie.css
@@ -1,0 +1,11 @@
+.form-view .toolbar {
+    display: table-cell;
+    vertical-align: middle;
+    margin: 0;
+    height: 80px;
+}
+
+.forms-view .frame {
+    /* 100% - toolbar height */
+    height: calc(100% - 80px);
+}


### PR DESCRIPTION
Add a specific css for ie lower than ie11
Override .form-view css attributes to have the wanted height in ie

Fixes [BS-14894](https://bonitasoft.atlassian.net/browse/BS-14894)