### PR TITLE
fix(csrf): change CSRF cookie name to be compliant with standards

### DIFF
--- a/server/src/main/java/org/bonitasoft/console/common/server/login/filter/TokenGeneratorFilter.java
+++ b/server/src/main/java/org/bonitasoft/console/common/server/login/filter/TokenGeneratorFilter.java
@@ -38,6 +38,7 @@ public class TokenGeneratorFilter implements Filter {
     public static final String API_TOKEN = "api_token";
 
     public static final String X_BONITA_API_TOKEN = "X-Bonita-API-Token";
+    public static final String BONITA_API_TOKEN = "Bonita-API-Token";
 
     protected static final Logger LOGGER = Logger.getLogger(TokenGeneratorFilter.class.getName());
 
@@ -60,7 +61,7 @@ public class TokenGeneratorFilter implements Filter {
         } else {
             res.addHeader(X_BONITA_API_TOKEN, apiTokenFromClient.toString());
         }
-        final Cookie csrfCookie = new Cookie(X_BONITA_API_TOKEN, apiTokenFromClient.toString());
+        final Cookie csrfCookie = new Cookie(BONITA_API_TOKEN, apiTokenFromClient.toString());
         csrfCookie.setPath(req.getContextPath());
         res.addCookie(csrfCookie);
         chain.doFilter(req, res);

--- a/server/src/test/java/org/bonitasoft/console/common/server/login/filter/TokenGeneratorFilterTest.java
+++ b/server/src/test/java/org/bonitasoft/console/common/server/login/filter/TokenGeneratorFilterTest.java
@@ -27,6 +27,7 @@ public class TokenGeneratorFilterTest {
 
     final String contextPath = "bonitaTest";
     final String bonitaTokenName = "X-Bonita-API-Token";
+    final String bonitaCookieName = "Bonita-API-Token";
     final String bonitaTokenValue = "sdfsdfjhvèzv";
 
     private final TokenGeneratorFilter tokenGeneratorFilter = new TokenGeneratorFilter();
@@ -44,9 +45,9 @@ public class TokenGeneratorFilterTest {
 
         tokenGeneratorFilter.doFilter(request, response, filterChain);
 
-        final Cookie csrfCookie = response.getCookie(bonitaTokenName);
+        final Cookie csrfCookie = response.getCookie(bonitaCookieName);
 
-        assertThat(csrfCookie.getName()).isEqualTo(bonitaTokenName);
+        assertThat(csrfCookie.getName()).isEqualTo(bonitaCookieName);
         assertThat(csrfCookie.getPath()).isEqualTo(contextPath);
         assertThat(csrfCookie.getValue()).isEqualTo(bonitaTokenValue);
 
@@ -60,9 +61,9 @@ public class TokenGeneratorFilterTest {
     public void should_add_security_token_in_headers_and_in_cookies_when_no_previous_call() throws Exception {
         tokenGeneratorFilter.doFilter(request, response, filterChain);
 
-        final Cookie csrfCookie = response.getCookie(bonitaTokenName);
+        final Cookie csrfCookie = response.getCookie(bonitaCookieName);
 
-        assertThat(csrfCookie.getName()).isEqualTo(bonitaTokenName);
+        assertThat(csrfCookie.getName()).isEqualTo(bonitaCookieName);
         assertThat(csrfCookie.getPath()).isEqualTo(contextPath);
         assertThat(csrfCookie.getValue()).isNotEqualTo(bonitaTokenValue);
 


### PR DESCRIPTION
CSRF token cookie should not have the same name as the one injected into
HTTP request headers.
Inspired from
[Cookie-to-header Token](https://en.wikipedia.org/wiki/Cross-site_request_forgery#Cookie-to-Header_Token)