### PR TITLE
fix(BS-15117) Custom permissions mapping and profiles with spaces

### DIFF
--- a/bonita-home/src/main/resources/client/platform/tenant-template/conf/custom-permissions-mapping.properties
+++ b/bonita-home/src/main/resources/client/platform/tenant-template/conf/custom-permissions-mapping.properties
@@ -5,12 +5,13 @@
 # <type>|<identifier>=[<permission list>]
 #
 # type can be 'profile' or 'user'
-# identifier is the username or the profile name
+# identifier is the username or the profile name. Special characters like white space must be replaced with their unicode value (For example \u0020 for the white space)
 # possible values for permissions can be found in the resources-permissions-mapping.properties file
 #
 ##
 # example: the profile User have now the permission Organization management
-#profile|User=[Organization management]
+#profile|User=[organization_visualization]
+#profile|Process\u0020manager=[organization_visualization]
 #
 # example: the user having username john have now the permission Organization management and Organization visualization
-#user|john=[Organization management, Organization visualization]
+#user|john=[organization_management, organization_visualization]

--- a/bonita-home/src/main/resources/client/platform/tenant-template/conf/dynamic-permissions-checks.properties
+++ b/bonita-home/src/main/resources/client/platform/tenant-template/conf/dynamic-permissions-checks.properties
@@ -4,10 +4,11 @@
 # If a dynamic check is defined on a resource it override the static check behavior
 # You can define dynamic rules like this:
 # <method>|<resource>=[<exclusions>, check <class name of the rule>]
-# exclusions is a list of elements like this: <type>|<identifier> where type is user or profile and identifier is the username or the profile name
+# exclusions is a list of elements like this: <type>|<identifier> where type is user or profile and identifier is the username or the profile name.
+# Special characters like white space must be replaced with their unicode value (For example \u0020 for the white space)
 #
 # example: to protect a case to only users that can start the process and to william.jobs, walter.bates and all users having the Administrator or User profile
-# POST|bpm/case=[user|william.jobs, user|walter.bates, profile|Administrator, profile|User, check|CasePermissionRule]
+# POST|bpm/case=[user|william.jobs, user|walter.bates, profile|Administrator, profile|Process\u0020Manager, check|CasePermissionRule]
 #
 ##
 

--- a/common/src/test/java/org/bonitasoft/console/common/server/preferences/properties/SimplePropertiesTest.java
+++ b/common/src/test/java/org/bonitasoft/console/common/server/preferences/properties/SimplePropertiesTest.java
@@ -20,7 +20,7 @@ public class SimplePropertiesTest {
     private static final File CUSTOM_PERMISSIONS_MAPPING_FILE = new File("src/test/resources/custom-permissions-mapping.properties");
 
     @Test
-    public void should_getProperty_return_the_right_compound_permissions() throws Exception {
+    public void getProperty_should_return_the_right_compound_permissions() throws Exception {
 
         final SimpleProperties tenantProperties = new SimpleProperties(COMPOUND_PERMISSIONS_MAPPING_FILE);
 
@@ -30,7 +30,7 @@ public class SimplePropertiesTest {
     }
 
     @Test
-    public void should_getProperty_return_the_right_resource_permissions() throws Exception {
+    public void getProperty_should_return_the_right_resource_permissions() throws Exception {
 
         final SimpleProperties tenantProperties = new SimpleProperties(RESOURCES_PERMISSIONS_MAPPING_FILE);
 
@@ -40,7 +40,7 @@ public class SimplePropertiesTest {
     }
 
     @Test
-    public void should_getProperty_return_the_right_custom_permissions() throws Exception {
+    public void getProperty_should_return_the_right_custom_permissions() throws Exception {
 
         final SimpleProperties tenantProperties = new SimpleProperties(CUSTOM_PERMISSIONS_MAPPING_FILE);
 
@@ -50,7 +50,7 @@ public class SimplePropertiesTest {
     }
 
     @Test
-    public void should_getProperty_return_the_right_custom_permissions_with_special_characters() throws Exception {
+    public void getProperty_should_return_the_right_custom_permissions_with_special_characters() throws Exception {
 
         final SimpleProperties tenantProperties = new SimpleProperties(CUSTOM_PERMISSIONS_MAPPING_FILE);
 
@@ -60,7 +60,7 @@ public class SimplePropertiesTest {
     }
 
     @Test
-    public void should_setProperty_add_the_right_compound_permissions_and_remove_remove_it() throws Exception {
+    public void setProperty_should_add_the_right_compound_permissions_and_remove_remove_it() throws Exception {
 
         final File compoundPermissionMappingWorkFile = File.createTempFile("compound-permissions-mapping", ".properties");
         compoundPermissionMappingWorkFile.deleteOnExit();
@@ -80,7 +80,7 @@ public class SimplePropertiesTest {
     }
 
     @Test
-    public void should_getProperty_return_the_right_permissions_list() throws Exception {
+    public void getPropertyAsSet_should_return_the_right_permissions_list() throws Exception {
 
         final SimpleProperties tenantProperties = new SimpleProperties(COMPOUND_PERMISSIONS_MAPPING_FILE);
 
@@ -90,7 +90,7 @@ public class SimplePropertiesTest {
     }
 
     @Test
-    public void should_getProperty_return_the_right_permissions_list_with_single_value() throws Exception {
+    public void getPropertyAsSet_should_return_the_right_permissions_list_with_single_value() throws Exception {
 
         final SimpleProperties tenantProperties = new SimpleProperties(COMPOUND_PERMISSIONS_MAPPING_FILE);
 
@@ -100,7 +100,7 @@ public class SimplePropertiesTest {
     }
 
     @Test
-    public void should_setPropertyAsSet_add_the_right_compound_permissions() throws Exception {
+    public void setPropertyAsSet_should_add_the_right_compound_permissions() throws Exception {
 
         final File compoundPermissionMappingWorkFile = File.createTempFile("compound-permissions-mapping", ".properties");
         compoundPermissionMappingWorkFile.deleteOnExit();
@@ -125,7 +125,7 @@ public class SimplePropertiesTest {
     }
 
     @Test
-    public void should_setPropertyAsSet_add_the_right_compound_permissions_with_an_empty_list() throws Exception {
+    public void setPropertyAsSet_should_add_the_right_compound_permissions_with_an_empty_list() throws Exception {
 
         final File compoundPermissionMappingWorkFile = File.createTempFile("compound-permissions-mapping", ".properties");
         compoundPermissionMappingWorkFile.deleteOnExit();

--- a/common/src/test/java/org/bonitasoft/console/common/server/preferences/properties/SimplePropertiesTest.java
+++ b/common/src/test/java/org/bonitasoft/console/common/server/preferences/properties/SimplePropertiesTest.java
@@ -50,6 +50,16 @@ public class SimplePropertiesTest {
     }
 
     @Test
+    public void should_getProperty_return_the_right_custom_permissions_with_special_characters() throws Exception {
+
+        final SimpleProperties tenantProperties = new SimpleProperties(CUSTOM_PERMISSIONS_MAPPING_FILE);
+
+        final String customValue = tenantProperties.getProperty("profile|HR manager");
+
+        Assert.assertEquals("[ManageProfiles]", customValue);
+    }
+
+    @Test
     public void should_setProperty_add_the_right_compound_permissions_and_remove_remove_it() throws Exception {
 
         final File compoundPermissionMappingWorkFile = File.createTempFile("compound-permissions-mapping", ".properties");

--- a/common/src/test/resources/custom-permissions-mapping.properties
+++ b/common/src/test/resources/custom-permissions-mapping.properties
@@ -1,1 +1,2 @@
-profile|User [ManageLooknFeel, ManageProfiles]
+profile|User=[ManageLooknFeel, ManageProfiles]
+profile|HR\u0020manager=[ManageProfiles]


### PR DESCRIPTION
Special characters like white space must be replaced with their unicode value (For example \u0020 for the white space)
Add unit test and guidance in the properties files

covers [BS-15117](https://bonitasoft.atlassian.net/browse/BS-15117)