### PR TITLE
TR/avoid rewriting URL with sso

### DIFF
--- a/forms/forms-server/src/main/java/org/bonitasoft/forms/server/filter/BPMURLSupportFilter.java
+++ b/forms/forms-server/src/main/java/org/bonitasoft/forms/server/filter/BPMURLSupportFilter.java
@@ -127,6 +127,11 @@ public class BPMURLSupportFilter implements Filter {
     public static final String RECAP_PARAM = "recap";
 
     /**
+     * Ticket parameter for SSO
+     */
+    public static final String TICKET_PARAM = "ticket";
+
+    /**
      * form type: entry
      */
     public static final String ENTRY_FORM = "entry";
@@ -188,7 +193,7 @@ public class BPMURLSupportFilter implements Filter {
             final HttpServletResponse httpServletResponse = (HttpServletResponse) response;
             final Map<String, String[]> parameters = new HashMap<String, String[]>(httpServletRequest.getParameterMap());
             final List<String> supportedParameterKeysList = Arrays.asList(FORM_LOCALE_URL_PARAM, TENANT_PARAM, UI_MODE_PARAM, THEME_PARAM,
-                    GWT_DEBUG_PARAM, TOKEN_URL_PARAM, AUTO_LOGIN_PARAM);
+                    GWT_DEBUG_PARAM, TOKEN_URL_PARAM, AUTO_LOGIN_PARAM, TICKET_PARAM);
             final Set<String> parameterKeys = new HashSet<String>(parameters.keySet());
             parameterKeys.removeAll(supportedParameterKeysList);
             if (!parameterKeys.isEmpty()) {


### PR DESCRIPTION
In case of a login with CAS, the URL get unnecessarily rewritten because the ticket parameter is not part of the supported parameters in the query string