### PR TITLE
fix(BS-15218) support task name with equals symbol in REST API

### DIFF
--- a/server/src/main/java/org/bonitasoft/web/rest/server/api/resource/CommonResource.java
+++ b/server/src/main/java/org/bonitasoft/web/rest/server/api/resource/CommonResource.java
@@ -23,9 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -107,7 +104,7 @@ public class CommonResource extends ServerResource {
             if (split.length < 2) {
                 results.put(split[0], null);
             } else {
-                results.put(split[0], split[1]);
+                results.put(split[0], parameter.substring(split[0].length() + 1));
             }
         }
         return results;
@@ -182,7 +179,7 @@ public class CommonResource extends ServerResource {
         super.doCatch(t);
 
         final String message = "Error while querying REST resource " + getClass().getName() + " message: " + t.getMessage();
-        ErrorMessage errorMessage = new ErrorMessage(t);
+        final ErrorMessage errorMessage = new ErrorMessage(t);
 
         getResponse().setStatus(getStatus(), message);
 
@@ -246,7 +243,7 @@ public class CommonResource extends ServerResource {
             final String[] parameterValues = values.split(",");
             if (parameterValues != null && parameterValues.length > 0) {
             	final List<Long> longValues = new ArrayList<>();
-            	for (String parameterValue : parameterValues) {
+            	for (final String parameterValue : parameterValues) {
 					longValues.add(convertToLong(parameterValue));
 				}
             	return longValues;
@@ -283,7 +280,7 @@ public class CommonResource extends ServerResource {
         setContentRange(getSearchPageNumber(), getSearchPageSize(), searchResult.getCount());
     }
 
-    protected void setContentRange(int pageNumber, int pageSize, long count) {
+    protected void setContentRange(final int pageNumber, final int pageSize, final long count) {
         final Series<Header> headers = getResponse().getHeaders();
         headers.add(new Header("Content-range", pageNumber + "-" + pageSize + "/" + count));
     }

--- a/server/src/test/java/org/bonitasoft/web/rest/server/api/resource/CommonResourceTest.java
+++ b/server/src/test/java/org/bonitasoft/web/rest/server/api/resource/CommonResourceTest.java
@@ -32,8 +32,8 @@ import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.restlet.Application;
 import org.restlet.Response;
-import org.restlet.data.Header;
 import org.restlet.data.Form;
+import org.restlet.data.Header;
 import org.restlet.data.Status;
 import org.restlet.util.Series;
 
@@ -44,7 +44,7 @@ public class CommonResourceTest extends RestletTest {
     private FakeService fakeService;
 
     @Spy
-    private Series<Header> headers = new Series<>(Header.class);
+    private final Series<Header> headers = new Series<>(Header.class);
 
     @Override
     protected Application configureApplication() {
@@ -149,15 +149,16 @@ public class CommonResourceTest extends RestletTest {
     @Test
     public void parseFilterShouldBuildExpectedMap() throws Exception {
         // given:
-        final List<String> filters = Arrays.asList("toto=17", "titi='EN_ECHEC'");
+        final List<String> filters = Arrays.asList("toto=17", "titi='EN_ECHEC'", "task=task=with=equal=in=name");
 
         // when:
         final Map<String, String> parseFilters = new CommonResource().parseFilters(filters);
 
         // then:
-        assertThat(parseFilters.size()).isEqualTo(2);
+        assertThat(parseFilters.size()).isEqualTo(3);
         assertThat(parseFilters.get("toto")).isEqualTo("17");
         assertThat(parseFilters.get("titi")).isEqualTo("'EN_ECHEC'");
+        assertThat(parseFilters.get("task")).isEqualTo("task=with=equal=in=name");
     }
 
     @Test
@@ -273,12 +274,12 @@ public class CommonResourceTest extends RestletTest {
     @Test
     public void getParametersAsList_should_support_value_with_comma() throws Exception {
         //given
-        CommonResource resource = spy(new CommonResource());
-        Form form = new Form("f=a=b&f=c=d,e");
+        final CommonResource resource = spy(new CommonResource());
+        final Form form = new Form("f=a=b&f=c=d,e");
         given(resource.getQuery()).willReturn(form);
 
         //when
-        List<String> parametersValues = resource.getParameterAsList("f");
+        final List<String> parametersValues = resource.getParameterAsList("f");
 
         //then
         assertThat(parametersValues).containsExactly("a=b", "c=d,e");
@@ -287,12 +288,12 @@ public class CommonResourceTest extends RestletTest {
     @Test
     public void getParametersAsList_should_return_emptyList_when_parameter_does_not_exist() throws Exception {
         //given
-        CommonResource resource = spy(new CommonResource());
-        Form form = new Form("f=a=b&f=c=d,e");
+        final CommonResource resource = spy(new CommonResource());
+        final Form form = new Form("f=a=b&f=c=d,e");
         given(resource.getQuery()).willReturn(form);
 
         //when
-        List<String> parametersValues = resource.getParameterAsList("anyAbsent");
+        final List<String> parametersValues = resource.getParameterAsList("anyAbsent");
 
         //then
         assertThat(parametersValues).isEmpty();


### PR DESCRIPTION
Parameters were incorrectly parsed for filters
Sorry for the addition of the "final" that should have been made in a separate commit

covers [BS-15218](https://bonitasoft.atlassian.net/browse/BS-15218)