### PR TITLE
fix(looknfeel): add compiled bootstrap.css to less archive

### DIFF
--- a/looknfeel/assemblyLESS.xml
+++ b/looknfeel/assemblyLESS.xml
@@ -25,5 +25,13 @@
 				<exclude>**/*.html</exclude>
 			</excludes>
 		</fileSet>
+		<!-- compiled bootstrap.min.css need to be added to less package since for now it is not compiled at runtime by portal -->
+		<fileSet>
+			<directory>${project.build.directory}/css</directory>
+			<outputDirectory></outputDirectory>
+			<includes>
+				<include>css/bootstrap.min.css</include>
+			</includes>
+		</fileSet>
 	</fileSets>
 </assembly>


### PR DESCRIPTION
In contrary to bonita.css, bootstrap.min.css is not compiled by portal while getting looknfeel from database.
That is why compiled bootstrap.min.css needs to be enbed in less archive.

Please also note that this is the less archive that is been used as portal looknfeel instead of css archive.