### PR TITLE
feat(paas_ready): reload security properties in debug

### DIFF
--- a/common/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java
+++ b/common/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java
@@ -23,11 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.bonitasoft.console.common.server.auth.AuthenticationFailedException;
 import org.bonitasoft.console.common.server.auth.AuthenticationManager;
 import org.bonitasoft.console.common.server.login.HttpServletRequestAccessor;
-import org.bonitasoft.console.common.server.login.LoginFailedException;
 import org.bonitasoft.console.common.server.login.datastore.Credentials;
-import org.bonitasoft.console.common.server.utils.PermissionsBuilder;
-import org.bonitasoft.console.common.server.utils.PermissionsBuilderAccessor;
-import org.bonitasoft.engine.session.APISession;
 
 /**
  * @author Chong Zhao
@@ -63,10 +59,6 @@ public class StandardAuthenticationManagerImpl implements AuthenticationManager 
                     + " does nothing. The subsequent engine login is enough to authenticate the user.)");
         }
         return Collections.emptyMap();
-    }
-
-    protected PermissionsBuilder createPermissionsBuilder(final APISession session) throws LoginFailedException {
-        return PermissionsBuilderAccessor.createPermissionBuilder(session);
     }
 
     @Override

--- a/common/src/main/java/org/bonitasoft/console/common/server/utils/PermissionsBuilder.java
+++ b/common/src/main/java/org/bonitasoft/console/common/server/utils/PermissionsBuilder.java
@@ -51,7 +51,7 @@ public class PermissionsBuilder {
         if (session.isTechnicalUser()) {
             permissions = Collections.emptySet();
         } else {
-            permissions = new HashSet<String>();
+            permissions = new HashSet<>();
             if (apiAuthorizationsCheckEnabled) {
                 addProfilesPermissions(permissions);
                 addCustomUserPermissions(permissions);
@@ -82,7 +82,7 @@ public class PermissionsBuilder {
      * @throws SearchException
      */
     Set<String> getAllPagesForUser(final Set<String> permissions) throws SearchException {
-        final Set<String> pageTokens = new HashSet<String>();
+        final Set<String> pageTokens = new HashSet<>();
         int profilesIndex = 0;
         int nbOfProfilesRetrieved = MAX_ELEMENTS_RETRIEVED;
         while (nbOfProfilesRetrieved == MAX_ELEMENTS_RETRIEVED) {
@@ -136,7 +136,7 @@ public class PermissionsBuilder {
     }
 
     Set<String> getCustomPermissions(final String type, final String identifier) {
-        final Set<String> profileSinglePermissions = new HashSet<String>();
+        final Set<String> profileSinglePermissions = new HashSet<>();
         final Set<String> customPermissionsForEntity = getCustomPermissionsRaw(type, identifier);
         for (final String customPermissionForEntity : customPermissionsForEntity) {
             final Set<String> simplePermissions = getCompoundPermissions(customPermissionForEntity);

--- a/common/src/main/java/org/bonitasoft/console/common/server/utils/PlatformManagementUtils.java
+++ b/common/src/main/java/org/bonitasoft/console/common/server/utils/PlatformManagementUtils.java
@@ -34,6 +34,8 @@ import org.bonitasoft.engine.util.APITypeManager;
  */
 public class PlatformManagementUtils {
 
+    private ConfigurationFilesManager configurationFilesManager = ConfigurationFilesManager.getInstance();
+
     private boolean isLocal() throws UnknownAPITypeException, ServerAPIException, IOException {
         return ApiAccessType.LOCAL.equals(APITypeManager.getAPIType());
     }
@@ -60,13 +62,13 @@ public class PlatformManagementUtils {
     private void retrieveTenantsConfiguration(PlatformAPI platformAPI) throws IOException {
         Map<Long, Map<String, byte[]>> clientPlatformConfigurations = platformAPI.getClientTenantConfigurations();
         for (Map.Entry<Long, Map<String, byte[]>> tenantConfiguration : clientPlatformConfigurations.entrySet()) {
-            ConfigurationFilesManager.getInstance().setTenantConfigurations(tenantConfiguration.getValue(), tenantConfiguration.getKey());
+            configurationFilesManager.setTenantConfigurations(tenantConfiguration.getValue(), tenantConfiguration.getKey());
         }
     }
 
     private void retrievePlatformConfiguration(PlatformAPI platformAPI) throws IOException {
         Map<String, byte[]> clientPlatformConfigurations = platformAPI.getClientPlatformConfigurations();
-        ConfigurationFilesManager.getInstance().setPlatformConfigurations(clientPlatformConfigurations);
+        configurationFilesManager.setPlatformConfigurations(clientPlatformConfigurations);
     }
 
     public void initializePlatformConfiguration() throws BonitaException, IOException {

--- a/common/src/test/java/org/bonitasoft/console/common/server/utils/PermissionsBuilderAccessorTest.java
+++ b/common/src/test/java/org/bonitasoft/console/common/server/utils/PermissionsBuilderAccessorTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2016 Bonitasoft S.A.
+ * Bonitasoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.console.common.server.utils;
+
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+
+import org.bonitasoft.console.common.server.login.LoginFailedException;
+import org.bonitasoft.console.common.server.preferences.properties.SecurityProperties;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author Baptiste Mesta
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PermissionsBuilderAccessorTest {
+
+    @Mock
+    private SecurityProperties securityProperties;
+    @Mock
+    private PlatformManagementUtils platformManagementUtils;
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void before() throws Exception {
+    }
+
+    @Test
+    public void should_reloadPropertiesIfInDebug_reload_properties_when_in_debug() throws Exception {
+        //given
+        doReturn(true).when(securityProperties).isAPIAuthorizationsCheckInDebugMode();
+        //when
+        PermissionsBuilderAccessor.reloadPropertiesIfInDebug(securityProperties, platformManagementUtils);
+        //then
+        verify(platformManagementUtils).initializePlatformConfiguration();
+    }
+
+    @Test
+    public void should_reloadPropertiesIfInDebug_do_not_reload_properties_when_not_in_debug() throws Exception {
+        //given
+        doReturn(false).when(securityProperties).isAPIAuthorizationsCheckInDebugMode();
+        //when
+        PermissionsBuilderAccessor.reloadPropertiesIfInDebug(securityProperties, platformManagementUtils);
+        //then
+        verify(platformManagementUtils, never()).initializePlatformConfiguration();
+    }
+
+    @Test
+    public void should_reloadPropertiesIfInDebug_handles_exception() throws Exception {
+        //given
+        doReturn(true).when(securityProperties).isAPIAuthorizationsCheckInDebugMode();
+        doThrow(IOException.class).when(platformManagementUtils).initializePlatformConfiguration();
+        //when
+        expectedException.expect(LoginFailedException.class);
+        expectedException.expectMessage("debug mode");
+        PermissionsBuilderAccessor.reloadPropertiesIfInDebug(securityProperties, platformManagementUtils);
+        //then exception
+    }
+
+}

--- a/server/src/main/java/org/bonitasoft/console/common/server/login/filter/RestAPIAuthorizationFilter.java
+++ b/server/src/main/java/org/bonitasoft/console/common/server/login/filter/RestAPIAuthorizationFilter.java
@@ -61,13 +61,12 @@ public class RestAPIAuthorizationFilter extends AbstractAuthorizationFilter {
     protected static final String PLATFORM_SESSION_PARAM_KEY = "platformSession";
     private final Boolean reload;
 
-
     public RestAPIAuthorizationFilter(final boolean reload) {
         this.reload = reload;
     }
 
     public RestAPIAuthorizationFilter() {
-        reload = null;//will be check every time
+        reload = null;//will check property from security-config
     }
 
     @Override
@@ -139,7 +138,8 @@ public class RestAPIAuthorizationFilter extends AbstractAuthorizationFilter {
         if (!resourceAuthorizations.isEmpty()) {
             //if there is a dynamic rule, use it to check the permissions
             final String requestBody = getRequestBody(request);
-            final APICallContext apiCallContext = new APICallContext(method, apiName, resourceName, resourceQualifiersAsString, request.getQueryString(), requestBody);
+            final APICallContext apiCallContext = new APICallContext(method, apiName, resourceName, resourceQualifiersAsString, request.getQueryString(),
+                    requestBody);
             return dynamicCheck(apiCallContext, userPermissions, resourceAuthorizations, apiSession);
         } else {
             //if there is no dynamic rule, use the static permissions
@@ -306,6 +306,6 @@ public class RestAPIAuthorizationFilter extends AbstractAuthorizationFilter {
     }
 
     private boolean shouldReload(final APISession apiSession) {
-        return reload == null ? PropertiesFactory.getSecurityProperties(apiSession.getTenantId()).isAPIAuthorizationsCheckInDebugMode():reload;
+        return reload == null ? PropertiesFactory.getSecurityProperties(apiSession.getTenantId()).isAPIAuthorizationsCheckInDebugMode() : reload;
     }
 }


### PR DESCRIPTION
when the debug mode is activated we reload security properties from the
database at each user login (i.e. when user permissions are construct)