### PR TITLE
fix(BS-15260) change first day of week for es locale

### DIFF
--- a/forms/forms-view/src/main/java/com/google/gwt/i18n/client/impl/cldr/DateTimeFormatInfoImpl_es.java
+++ b/forms/forms-view/src/main/java/com/google/gwt/i18n/client/impl/cldr/DateTimeFormatInfoImpl_es.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2012 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.i18n.client.impl.cldr;
+
+// Override GWT version to set first day of week to monday
+// DO NOT EDIT - GENERATED FROM CLDR AND ICU DATA
+// cldrVersion=21.0
+// number=$Revision: 6546 Google $
+// type=es
+// date=$Date: 2012-02-07 13:32:35 -0500 (Tue, 07 Feb 2012) $
+
+/**
+ * Implementation of DateTimeFormatInfo for the "es" locale.
+ */
+public class DateTimeFormatInfoImpl_es extends DateTimeFormatInfoImpl {
+
+    @Override
+    public String[] ampms() {
+        return new String[] {
+                "a.m.",
+                "p.m."
+        };
+    }
+
+    @Override
+    public String dateFormatFull() {
+        return "EEEE, d 'de' MMMM 'de' y";
+    }
+
+    @Override
+    public String dateFormatLong() {
+        return "d 'de' MMMM 'de' y";
+    }
+
+    @Override
+    public String dateFormatMedium() {
+        return "dd/MM/yyyy";
+    }
+
+    @Override
+    public String dateFormatShort() {
+        return "dd/MM/yy";
+    }
+
+    @Override
+    public String[] erasFull() {
+        return new String[] {
+                "antes de Cristo",
+                "anno Dómini"
+        };
+    }
+
+    @Override
+    public String[] erasShort() {
+        return new String[] {
+                "a.C.",
+                "d.C."
+        };
+    }
+
+    @Override
+    public int firstDayOfTheWeek() {
+        return 1;
+    }
+
+    @Override
+    public String formatHour12Minute() {
+        return "hh:mm a";
+    }
+
+    @Override
+    public String formatHour12MinuteSecond() {
+        return "hh:mm:ss a";
+    }
+
+    @Override
+    public String formatMonthAbbrevDay() {
+        return "d MMM";
+    }
+
+    @Override
+    public String formatMonthFullDay() {
+        return "d 'de' MMMM";
+    }
+
+    @Override
+    public String formatMonthFullWeekdayDay() {
+        return "EEEE d MMMM";
+    }
+
+    @Override
+    public String formatMonthNumDay() {
+        return "d/M";
+    }
+
+    @Override
+    public String formatYearMonthAbbrev() {
+        return "MMM y";
+    }
+
+    @Override
+    public String formatYearMonthAbbrevDay() {
+        return "d MMM y";
+    }
+
+    @Override
+    public String formatYearMonthFull() {
+        return "MMMM 'de' y";
+    }
+
+    @Override
+    public String formatYearMonthFullDay() {
+        return "d 'de' MMMM 'de' y";
+    }
+
+    @Override
+    public String formatYearMonthNum() {
+        return "M/y";
+    }
+
+    @Override
+    public String formatYearMonthNumDay() {
+        return "d/M/y";
+    }
+
+    @Override
+    public String formatYearMonthWeekdayDay() {
+        return "EEE, d MMM y";
+    }
+
+    @Override
+    public String formatYearQuarterFull() {
+        return "QQQQ y";
+    }
+
+    @Override
+    public String formatYearQuarterShort() {
+        return "Q y";
+    }
+
+    @Override
+    public String[] monthsFull() {
+        return new String[] {
+                "enero",
+                "febrero",
+                "marzo",
+                "abril",
+                "mayo",
+                "junio",
+                "julio",
+                "agosto",
+                "septiembre",
+                "octubre",
+                "noviembre",
+                "diciembre"
+        };
+    }
+
+    @Override
+    public String[] monthsNarrow() {
+        return new String[] {
+                "E",
+                "F",
+                "M",
+                "A",
+                "M",
+                "J",
+                "J",
+                "A",
+                "S",
+                "O",
+                "N",
+                "D"
+        };
+    }
+
+    @Override
+    public String[] monthsShort() {
+        return new String[] {
+                "ene",
+                "feb",
+                "mar",
+                "abr",
+                "may",
+                "jun",
+                "jul",
+                "ago",
+                "sep",
+                "oct",
+                "nov",
+                "dic"
+        };
+    }
+
+    @Override
+    public String[] monthsShortStandalone() {
+        return new String[] {
+                "ene",
+                "feb",
+                "mar",
+                "abr",
+                "mayo",
+                "jun",
+                "jul",
+                "ago",
+                "sep",
+                "oct",
+                "nov",
+                "dic"
+        };
+    }
+
+    @Override
+    public String[] quartersFull() {
+        return new String[] {
+                "1er trimestre",
+                "2º trimestre",
+                "3er trimestre",
+                "4º trimestre"
+        };
+    }
+
+    @Override
+    public String[] quartersShort() {
+        return new String[] {
+                "T1",
+                "T2",
+                "T3",
+                "T4"
+        };
+    }
+
+    @Override
+    public String[] weekdaysFull() {
+        return new String[] {
+                "domingo",
+                "lunes",
+                "martes",
+                "miércoles",
+                "jueves",
+                "viernes",
+                "sábado"
+        };
+    }
+
+    @Override
+    public String[] weekdaysNarrow() {
+        return new String[] {
+                "D",
+                "L",
+                "M",
+                "X",
+                "J",
+                "V",
+                "S"
+        };
+    }
+
+    @Override
+    public String[] weekdaysShort() {
+        return new String[] {
+                "dom",
+                "lun",
+                "mar",
+                "mié",
+                "jue",
+                "vie",
+                "sáb"
+        };
+    }
+}


### PR DESCRIPTION
Patch DateTimeFormatInfoImpl_es to set the first day of week to Monday
for Spanish locale in 6.x forms' date picker
Couldn't find a better solution. I guess the clean solution would be to support the locale es_ES (which has the first day of week set to Monday) instead of just es, but it has huge impacts (we would need to do the same portal-side or handle the fact that the locale passed to the forms URL is not the same + crowdin changes...)

covers [BS-15260](https://bonitasoft.atlassian.net/browse/BS-15260)