### PR TITLE
fix(multitenancy): remove tenantid from url when default

### DIFF
--- a/server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java
+++ b/server/src/main/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImpl.java
@@ -28,6 +28,7 @@ import org.bonitasoft.console.common.server.login.HttpServletRequestAccessor;
 import org.bonitasoft.console.common.server.login.PortalCookies;
 import org.bonitasoft.console.common.server.login.TenantIdAccessor;
 import org.bonitasoft.console.common.server.login.datastore.Credentials;
+import org.bonitasoft.console.common.server.utils.TenantsManagementUtils;
 
 /**
  * @author Chong Zhao
@@ -48,13 +49,23 @@ public class StandardAuthenticationManagerImpl implements AuthenticationManager 
             context += "/mobile";
         }
         url.append(context).append(AuthenticationManager.LOGIN_PAGE).append("?");
-        url.append(AuthenticationManager.TENANT).append("=").append(getTenantId(request)).append("&");
+        long tenantId = getTenantId(request);
+        if (tenantId != getDefaultTenantId()) {
+            url.append(AuthenticationManager.TENANT).append("=").append(tenantId).append("&");
+        }
         url.append(AuthenticationManager.REDIRECT_URL).append("=").append(redirectURL);
         return url.toString();
     }
 
     private long getTenantId(HttpServletRequestAccessor request) throws ServletException {
         return new TenantIdAccessor(request).getTenantIdFromRequestOrCookie();
+    }
+
+    /**
+     * protected for test purpose
+     */
+    protected long getDefaultTenantId() {
+        return TenantsManagementUtils.getDefaultTenantId();
     }
 
     @Override

--- a/server/src/test/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImplTest.java
+++ b/server/src/test/java/org/bonitasoft/console/common/server/auth/impl/standard/StandardAuthenticationManagerImplTest.java
@@ -1,6 +1,8 @@
 package org.bonitasoft.console.common.server.auth.impl.standard;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import javax.servlet.http.Cookie;
@@ -8,14 +10,17 @@ import javax.servlet.http.Cookie;
 import org.bonitasoft.console.common.server.login.HttpServletRequestAccessor;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+@RunWith(MockitoJUnitRunner.class)
 public class StandardAuthenticationManagerImplTest {
 
     private MockHttpServletRequest request;
     private HttpServletRequestAccessor requestAccessor;
 
-    private StandardAuthenticationManagerImpl standardLoginManagerImpl = new StandardAuthenticationManagerImpl();
+    private StandardAuthenticationManagerImpl standardLoginManagerImpl = spy(new StandardAuthenticationManagerImpl());
 
 
     @Before
@@ -23,6 +28,7 @@ public class StandardAuthenticationManagerImplTest {
         request = new MockHttpServletRequest();
         request.setContextPath("bonita");
         request.setParameter("tenant", "1");
+        doReturn(2L).when(standardLoginManagerImpl).getDefaultTenantId();
 
         requestAccessor = new HttpServletRequestAccessor(request);
     }
@@ -76,5 +82,15 @@ public class StandardAuthenticationManagerImplTest {
         String loginURL = standardLoginManagerImpl.getLoginPageURL(requestAccessor, redirectUrl);
 
         assertThat(loginURL).isEqualToIgnoringCase("bonita/login.jsp?tenant=123&redirectUrl=%2Fportal%2Fhomepage");
+    }
+
+    @Test
+    public void should_not_add_tenantid_when_it_is_default_one() throws Exception {
+        when(standardLoginManagerImpl.getDefaultTenantId()).thenReturn(123L);
+        request.setParameter("tenant", "123");
+
+        String loginURL = standardLoginManagerImpl.getLoginPageURL(requestAccessor, "%2Fportal%2Fhomepage");
+
+        assertThat(loginURL).isEqualToIgnoringCase("bonita/login.jsp?redirectUrl=%2Fportal%2Fhomepage");
     }
 }

--- a/server/src/test/java/org/bonitasoft/console/common/server/login/filter/AuthenticationFilterTest.java
+++ b/server/src/test/java/org/bonitasoft/console/common/server/login/filter/AuthenticationFilterTest.java
@@ -82,7 +82,7 @@ public class AuthenticationFilterTest {
         initMocks(this);
         doReturn(httpSession).when(request).getHttpSession();
         when(request.asHttpServletRequest()).thenReturn(httpRequest);
-        doReturn(new StandardAuthenticationManagerImpl()).when(authenticationFilter).getAuthenticationManager(any(TenantIdAccessor.class));
+        doReturn(new FakeAuthenticationManager(1L)).when(authenticationFilter).getAuthenticationManager(any(TenantIdAccessor.class));
         when(httpRequest.getRequestURL()).thenReturn(new StringBuffer());
         when(request.getTenantId()).thenReturn("1");
     }

--- a/server/src/test/java/org/bonitasoft/console/common/server/login/filter/FakeAuthenticationManager.java
+++ b/server/src/test/java/org/bonitasoft/console/common/server/login/filter/FakeAuthenticationManager.java
@@ -1,0 +1,17 @@
+package org.bonitasoft.console.common.server.login.filter;
+
+import org.bonitasoft.console.common.server.auth.impl.standard.StandardAuthenticationManagerImpl;
+
+public class FakeAuthenticationManager extends StandardAuthenticationManagerImpl {
+
+    private long defaultTenantId;
+
+    public FakeAuthenticationManager(long defaultTenantId) {
+        this.defaultTenantId = defaultTenantId;
+    }
+
+    @Override
+    protected long getDefaultTenantId() {
+        return defaultTenantId;
+    }
+}


### PR DESCRIPTION
When current tenant is the defualt one, do not add tenant parameter in login url

Relates to [BS-8234](https://bonitasoft.atlassian.net/browse/BS-8234)

Tests run no my computer ;-)