### PR TITLE
TR(dependencies) remove engine client and common form bonita-web

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -24,10 +24,12 @@
         <dependency>
             <groupId>org.bonitasoft.engine</groupId>
             <artifactId>bonita-client</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bonitasoft.engine</groupId>
             <artifactId>bonita-common</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bonitasoft.engine</groupId>

--- a/forms/forms-server/pom.xml
+++ b/forms/forms-server/pom.xml
@@ -52,10 +52,12 @@
 		<dependency>
 			<groupId>org.bonitasoft.engine</groupId>
 			<artifactId>bonita-client</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.bonitasoft.engine</groupId>
 			<artifactId>bonita-common</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.ehcache</groupId>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -24,6 +24,11 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bonitasoft.engine</groupId>
+            <artifactId>bonita-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
 		<!-- Compile dependency -->
 		<dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -44,10 +44,12 @@
         <dependency>
             <groupId>org.bonitasoft.engine</groupId>
             <artifactId>bonita-client</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bonitasoft.engine</groupId>
             <artifactId>bonita-common</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!--Web extensions-->


### PR DESCRIPTION
This PR removes engine client and common form bonita-web as they are added in distrib project

Change the scope of bonita-client and bonita-common dependencies to
provided so that they are added to the war in bonita-distrib project
only when necessary (the EAR war shouldn't embbed them for example)

covers [BS-14766](https://bonitasoft.atlassian.net/browse/BS-14766)

should be merged with bonitasoft/bonita-web-sp/pull/75, bonitasoft/bonita-distrib/pull/37 and bonitasoft/bonita-distrib-sp/pull/25