### PR TITLE
fix(BS-15125) restore call to isInvolvedInProcessInstance Method

### DIFF
--- a/forms/forms-server/src/main/java/org/bonitasoft/forms/server/api/impl/FormWorkflowAPIImpl.java
+++ b/forms/forms-server/src/main/java/org/bonitasoft/forms/server/api/impl/FormWorkflowAPIImpl.java
@@ -900,10 +900,9 @@ public class FormWorkflowAPIImpl implements IFormWorkflowAPI {
     @Override
     public boolean canUserSeeProcessInstance(final APISession session, final long processInstanceID)
             throws ProcessInstanceNotFoundException, BPMEngineException, InvalidSessionException, UserNotFoundException, ProcessDefinitionNotFoundException {
-        return true;
-        //TODO: restore once BS-15125 has been fixed
-        //        final ProcessAPI processAPI = getBpmEngineAPIUtil().getProcessAPI(session);
-        //        boolean involvedInProcessInstance = processAPI.isInvolvedInProcessInstance(session.getUserId(), processInstanceID);
+        final ProcessAPI processAPI = getBpmEngineAPIUtil().getProcessAPI(session);
+        return processAPI.isInvolvedInProcessInstance(session.getUserId(), processInstanceID);
+        //restore this if the manager of a user should see his instances
         //        if (!involvedInProcessInstance) {
         //            try {
         //                involvedInProcessInstance = processAPI.isManagerOfUserInvolvedInProcessInstance(session.getUserId(), processInstanceID);
@@ -915,7 +914,7 @@ public class FormWorkflowAPIImpl implements IFormWorkflowAPI {
         //                throw new BPMEngineException(e);
         //            }
         //        }
-        //        return involvedInProcessInstance;
+        //return involvedInProcessInstance;
     }
 
     /**

--- a/forms/forms-server/src/main/java/org/bonitasoft/forms/server/api/impl/FormWorkflowAPIImpl.java
+++ b/forms/forms-server/src/main/java/org/bonitasoft/forms/server/api/impl/FormWorkflowAPIImpl.java
@@ -874,24 +874,6 @@ public class FormWorkflowAPIImpl implements IFormWorkflowAPI {
             ActivityInstanceNotFoundException, UserNotFoundException {
         final ProcessAPI processAPI = getBpmEngineAPIUtil().getProcessAPI(session);
         return processAPI.isInvolvedInHumanTaskInstance(session.getUserId(), humanTaskInstanceId);
-        //restore this if the manager of a user should see his tasks
-        //        if (!isInvolvedInHumanTaskInstance && userId != -1L) {
-        //            try {
-        //                final IdentityAPI identityAPI = getBpmEngineAPIUtil().getIdentityAPI(session);
-        //                if (session.getUserId() != identityAPI.getUser(userId).getManagerUserId()) {
-        //                    return false;
-        //                } else {
-        //                    isInvolvedInHumanTaskInstance = processAPI.isInvolvedInHumanTaskInstance(userId, humanTaskInstanceId);
-        //                }
-        //            } catch (final BonitaException e) {
-        //                if (LOGGER.isLoggable(Level.SEVERE)) {
-        //                    LOGGER.log(Level.SEVERE,
-        //                            "The engine was not able to find out if the user is a manager of a user involved in the task " + humanTaskInstanceId);
-        //                }
-        //                throw new BPMEngineException(e);
-        //            }
-        //        }
-        //        return isInvolvedInHumanTaskInstance;
     }
 
     /**
@@ -902,19 +884,6 @@ public class FormWorkflowAPIImpl implements IFormWorkflowAPI {
             throws ProcessInstanceNotFoundException, BPMEngineException, InvalidSessionException, UserNotFoundException, ProcessDefinitionNotFoundException {
         final ProcessAPI processAPI = getBpmEngineAPIUtil().getProcessAPI(session);
         return processAPI.isInvolvedInProcessInstance(session.getUserId(), processInstanceID);
-        //restore this if the manager of a user should see his instances
-        //        if (!involvedInProcessInstance) {
-        //            try {
-        //                involvedInProcessInstance = processAPI.isManagerOfUserInvolvedInProcessInstance(session.getUserId(), processInstanceID);
-        //            } catch (final BonitaException e) {
-        //                if (LOGGER.isLoggable(Level.SEVERE)) {
-        //                    LOGGER.log(Level.SEVERE,
-        //                            "The engine was not able to find out if the user is a manager of a user involved in the process instance " + processInstanceID);
-        //                }
-        //                throw new BPMEngineException(e);
-        //            }
-        //        }
-        //return involvedInProcessInstance;
     }
 
     /**

--- a/forms/forms-server/src/test/java/org/bonitasoft/forms/server/api/impl/FormWorkflowAPIImplTest.java
+++ b/forms/forms-server/src/test/java/org/bonitasoft/forms/server/api/impl/FormWorkflowAPIImplTest.java
@@ -78,14 +78,12 @@ public class FormWorkflowAPIImplTest {
 
     @Test
     public void should_canUserSeeProcessInstance_call_engine_api() throws Exception {
-        final boolean expected = true;
-        checkCanUserSeeProcessInstanceWhenApiReturn(expected);
+        checkCanUserSeeProcessInstanceWhenApiReturn(true);
     }
 
     @Test
     public void should_canUserSeeProcessInstance_call_engine_api_false() throws Exception {
-        final boolean expected = false;
-        checkCanUserSeeProcessInstanceWhenApiReturn(expected);
+        checkCanUserSeeProcessInstanceWhenApiReturn(false);
     }
 
     private void checkCanUserSeeProcessInstanceWhenApiReturn(final boolean expected) throws Exception {

--- a/forms/forms-server/src/test/java/org/bonitasoft/forms/server/api/impl/FormWorkflowAPIImplTest.java
+++ b/forms/forms-server/src/test/java/org/bonitasoft/forms/server/api/impl/FormWorkflowAPIImplTest.java
@@ -27,7 +27,6 @@ import org.bonitasoft.forms.client.model.FormAction;
 import org.bonitasoft.forms.client.model.exception.ForbiddenFormAccessException;
 import org.bonitasoft.forms.server.api.IFormExpressionsAPI;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -77,16 +76,12 @@ public class FormWorkflowAPIImplTest {
         doReturn(processApi).when(bpmEngineAPIUtil).getProcessAPI(session);
     }
 
-    //TODO restore once BS-15125 has been fixed
-    @Ignore
     @Test
     public void should_canUserSeeProcessInstance_call_engine_api() throws Exception {
         final boolean expected = true;
         checkCanUserSeeProcessInstanceWhenApiReturn(expected);
     }
 
-    //TODO restore once BS-15125 has been fixed
-    @Ignore
     @Test
     public void should_canUserSeeProcessInstance_call_engine_api_false() throws Exception {
         final boolean expected = false;


### PR DESCRIPTION
- restore call to isInvolvedInProcessInstance engine method in 6.x forms
for process instance overview access control

Covers [BS-15125](https://bonitasoft.atlassian.net/browse/BS-15125)