### PR TITLE
fix(avatar): ignore icon on update  if empty

### DIFF
--- a/server/src/main/java/org/bonitasoft/web/rest/server/datastore/organization/UserDatastore.java
+++ b/server/src/main/java/org/bonitasoft/web/rest/server/datastore/organization/UserDatastore.java
@@ -17,6 +17,7 @@ package org.bonitasoft.web.rest.server.datastore.organization;
 import java.util.List;
 import java.util.Map;
 
+import org.bonitasoft.console.common.server.utils.BonitaHomeFolderAccessor;
 import org.bonitasoft.engine.exception.SearchException;
 import org.bonitasoft.engine.identity.User;
 import org.bonitasoft.engine.identity.UserCreator;
@@ -65,9 +66,13 @@ public class UserDatastore extends CommonDatastore<UserItem, User>
     }
 
     public UserItem update(final APIID id, final Map<String, String> attributes) {
-        UserUpdater userUpdater = new UserUpdaterConverter().convert(attributes, getEngineSession().getTenantId());
+        UserUpdater userUpdater = new UserUpdaterConverter().convert(attributes, getEngineSession().getTenantId(), getBonitaHomeFolderAccessor());
         User user = getUserEngineClient().update(id.toLong(), userUpdater);
         return userItemConverter.convert(user);
+    }
+
+    BonitaHomeFolderAccessor getBonitaHomeFolderAccessor() {
+        return new BonitaHomeFolderAccessor();
     }
 
     @Override

--- a/server/src/main/java/org/bonitasoft/web/rest/server/datastore/organization/UserUpdaterConverter.java
+++ b/server/src/main/java/org/bonitasoft/web/rest/server/datastore/organization/UserUpdaterConverter.java
@@ -20,10 +20,11 @@ import org.bonitasoft.console.common.server.utils.BonitaHomeFolderAccessor;
 import org.bonitasoft.console.common.server.utils.IconDescriptor;
 import org.bonitasoft.engine.identity.UserUpdater;
 import org.bonitasoft.web.rest.model.identity.UserItem;
+import org.bonitasoft.web.toolkit.client.common.util.StringUtil;
 
 public class UserUpdaterConverter {
 
-    public UserUpdater convert(Map<String, String> attributes, long tenantId) {
+    public UserUpdater convert(Map<String, String> attributes, long tenantId, BonitaHomeFolderAccessor bonitaHomeFolderAccessor) {
         UserUpdater userUpdater = new UserUpdater();
 
         if (attributes.containsKey(UserItem.ATTRIBUTE_FIRSTNAME)) {
@@ -42,8 +43,8 @@ public class UserUpdaterConverter {
             Long managerId = getManagerId(attributes);
             userUpdater.setManagerId(managerId);
         }
-        if (attributes.containsKey(UserItem.ATTRIBUTE_ICON)) {
-            IconDescriptor iconDescriptor = new BonitaHomeFolderAccessor().getIconFromFileSystem(attributes.get(UserItem.ATTRIBUTE_ICON), tenantId);
+        if (!StringUtil.isBlank(attributes.get(UserItem.ATTRIBUTE_ICON))) {
+            IconDescriptor iconDescriptor = bonitaHomeFolderAccessor.getIconFromFileSystem(attributes.get(UserItem.ATTRIBUTE_ICON), tenantId);
             userUpdater.setIcon(iconDescriptor.getFilename(), iconDescriptor.getContent());
         }
         if (attributes.containsKey(UserItem.ATTRIBUTE_TITLE)) {


### PR DESCRIPTION
it is the same issue that happened on roles

Closes [BS-15474](https://bonitasoft.atlassian.net/browse/BS-15474)