### PR TITLE
feat(task-pages) Update default pages description for custom profiles

### DIFF
--- a/server/src/main/java/org/bonitasoft/web/rest/server/datastore/profile/PageLister.java
+++ b/server/src/main/java/org/bonitasoft/web/rest/server/datastore/profile/PageLister.java
@@ -16,7 +16,7 @@
  */
 package org.bonitasoft.web.rest.server.datastore.profile;
 
-import static org.bonitasoft.web.toolkit.client.common.i18n.AbstractI18n.*;
+import static org.bonitasoft.web.toolkit.client.common.i18n.AbstractI18n._;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,23 +34,23 @@ public class PageLister {
         pages.add(new BonitaPageItem("tasklistinguser", _("For user-type of profiles. To view and do tasks  if he is a candidate"), _("For user-type of profiles. To view and do tasks  if he is a candidate"), _("Tasks")));
         pages.add(new BonitaPageItem("tasklistingadmin", _("For administrator-type of profiles. To monitor task completion for all processes"), _("For administrator-type of profiles. To monitor task completion for all processes"), _("Tasks")));
         pages.add(new BonitaPageItem("tasklistingpm", _("For process manager-type of profiles. To monitor task completion, only for processes under her responsibility"), _("For process manager-type of profiles. To monitor task completion, only for processes under her responsibility"), _("Tasks")));
-        pages.add(new BonitaPageItem("caselistinguser", _("visualize cases"), _("visualize cases"), _("Cases")));
-        pages.add(new BonitaPageItem("caselistingadmin", _("manage cases"), _("manage cases"), _("Cases")));
-        pages.add(new BonitaPageItem("caselistingpm", _("Manage cases of processes that an entity with this profile can supervise as PM."), _("Manage cases of processes that an entity with this profile can supervise as PM."), _("Cases")));
-        pages.add(new BonitaPageItem("processlistinguser", _("visualize & start processes"), _("visualize & start processes"), _("Processes")));
-        pages.add(new BonitaPageItem("processlistingadmin", _("manage processes"), _("manage processes"), _("Processes")));
-        pages.add(new BonitaPageItem("processlistingpm", _("Manage processes that an entity with this profile can supervise as PM."), _("Manage processes that an entity with this profile can supervise as PM."), _("Processes")));
-        pages.add(new BonitaPageItem("userlistingadmin", _("manage users"), _("manage users"), _("Users")));
-        pages.add(new BonitaPageItem("grouplistingadmin", _("manage groups"), _("manage groups"), _("Groups")));
-        pages.add(new BonitaPageItem("rolelistingadmin", _("manage roles"), _("manage roles"), _("Roles")));
-        pages.add(new BonitaPageItem("importexportorganization", _("import/export organization"), _("import/export organization"), _("Import/Export")));
-        pages.add(new BonitaPageItem("profilelisting", _("user privilege settings"),  _("user privilege settings"), _("Profiles")));
-        pages.add(new BonitaPageItem("reportlistingadminext", _("Monitoring"), _("Monitoring"), _("Analytics")));
+        pages.add(new BonitaPageItem("caselistinguser", _("For user-type of profiles. To visualize cases started by the user or cases he has worked on"), _("For user-type of profiles. To visualize cases started by the user or cases he has worked on"), _("Cases")));
+        pages.add(new BonitaPageItem("caselistingadmin", _("For administrator-type of profiles. To monitor cases of all processes"), _("For administrator-type of profiles. To monitor cases of all processes"), _("Cases")));
+        pages.add(new BonitaPageItem("caselistingpm", _("For process manager-type of profiles. To monitor cases of processes under her responsibility"), _("For process manager-type of profiles. To monitor cases of processes under her responsibility"), _("Cases")));
+        pages.add(new BonitaPageItem("processlistinguser", _("For user-type of profiles. To visualize processes and start cases"), _("For user-type of profiles. To visualize processes and start cases"), _("Processes")));
+        pages.add(new BonitaPageItem("processlistingadmin", _("For administrator-type of profiles. To manage processes: install, delete and configure, for all processes"), _("For administrator-type of profiles. To manage processes: install, delete and configure, for all processes"), _("Processes")));
+        pages.add(new BonitaPageItem("processlistingpm", _("For process manager-type of profiles. To manage processes under her responsibility"), _("For process manager-type of profiles. To manage processes under her responsibility"), _("Processes")));
+        pages.add(new BonitaPageItem("userlistingadmin", _("Manage users"), _("Manage users"), _("Users")));
+        pages.add(new BonitaPageItem("grouplistingadmin", _("Manage groups"), _("Manage groups"), _("Groups")));
+        pages.add(new BonitaPageItem("rolelistingadmin", _("Manage roles"), _("Manage roles"), _("Roles")));
+        pages.add(new BonitaPageItem("importexportorganization", _("Import/export organization"), _("Import/export organization"), _("Import/Export")));
+        pages.add(new BonitaPageItem("profilelisting", _("User privilege settings"),  _("User privilege settings"), _("Profiles")));
+        pages.add(new BonitaPageItem("reportlistingadminext", _("Analytics"), _("Analytics"), _("Analytics")));
         pages.add(new BonitaPageItem("thememoredetailsadminext", _("Manage Look and Feel"), _("Manage Look and Feel"), _("Look and Feel")));
         pages.add(new BonitaPageItem("pagelisting", _("Manage custom pages"), _("Manage custom pages"), _("Custom Pages")));
         pages.add(new BonitaPageItem("applicationslistingadmin", _("Manage applications"), _("Manage applications"), _("Applications")));
-        pages.add(new BonitaPageItem("monitoringadmin", _("Monitoring"), _("Monitoring"), _("Monitoring")));
-        pages.add(new BonitaPageItem("monitoringpm", _("Monitoring"), _("Monitoring"), _("Monitoring")));
+        pages.add(new BonitaPageItem("monitoringadmin", _("For administrator-type of profiles. To monitor all processes"), _("For administrator-type of profiles. To monitor all processes"), _("Monitoring")));
+        pages.add(new BonitaPageItem("monitoringpm", _("For process manager-type of profiles. To monitor processes under her responsibility"), _("For process manager-type of profiles. To monitor processes under her responsibility"), _("Monitoring")));
         pages.add(new BonitaPageItem("licensemonitoringadmin", _("License"), _("License"), _("License")));
     }
 


### PR DESCRIPTION
Make sure the names and descriptions of the default pages are clear enough in the profile edition popup. Especially the distinction between admin PM and user pages

Linked to  [bonitasoft/bonita-qa-tools#17](https://github.com/bonitasoft/bonita-qa-tools/pull/17)