### PR TITLE
fix (BS-15533) No redirection to tasklist after submit form in Portal with 6.x instantiation form

### DIFF
--- a/portal/src/main/java/org/bonitasoft/console/client/user/task/action/TaskExecutionCallbackBehavior.java
+++ b/portal/src/main/java/org/bonitasoft/console/client/user/task/action/TaskExecutionCallbackBehavior.java
@@ -2,9 +2,7 @@ package org.bonitasoft.console.client.user.task.action;
 
 import static org.bonitasoft.web.toolkit.client.common.i18n.AbstractI18n._;
 
-import org.bonitasoft.console.client.user.task.view.PerformTaskPage;
 import org.bonitasoft.console.client.user.task.view.TasksListingPage;
-import org.bonitasoft.console.client.user.task.view.more.HumanTaskMoreDetailsPage;
 import org.bonitasoft.web.toolkit.client.ClientApplicationURL;
 import org.bonitasoft.web.toolkit.client.ViewController;
 import org.bonitasoft.web.toolkit.client.common.texttemplate.Arg;
@@ -30,12 +28,7 @@ public class TaskExecutionCallbackBehavior {
     }
 
     protected void redirectToTaskList() {
-        if (HumanTaskMoreDetailsPage.TOKEN.equals(ClientApplicationURL.getPageToken())
-                || PerformTaskPage.TOKEN.equals(ClientApplicationURL.getPageToken())) {
-            History.newItem("?_p=" + TasksListingPage.TOKEN + "&_pf=" + ClientApplicationURL.getProfileId());
-        } else {
-            ViewController.refreshCurrentPage();
-        }
+        History.newItem("?_p=" + TasksListingPage.TOKEN + "&_pf=" + ClientApplicationURL.getProfileId());
     }
 
     public void onSuccess(final String responseContent) {


### PR DESCRIPTION
When starting a process with a 6.x form, if you click on the link to the
task in the confirmation message you end up with a task form displayed
in the process start page. So the redirection to the task list should
take the process start page token into account

Covers [BS-15533](https://bonitasoft.atlassian.net/browse/BS-15533)