### PR TITLE
fix(rest-api) remove stacktraces in rest responses

### DIFF
--- a/common/src/main/java/org/bonitasoft/web/toolkit/client/common/json/JSonSerializer.java
+++ b/common/src/main/java/org/bonitasoft/web/toolkit/client/common/json/JSonSerializer.java
@@ -94,18 +94,6 @@ public class JSonSerializer extends JSonUtil {
         json.append(quote("exception")).append(":").append(quote(e.getClass().toString()));
         json.append(",");
         json.append(quote("message")).append(":").append(quote(e.getMessage()));
-
-        if (e.getStackTrace() != null) {
-
-            json.append(",");
-            json.append(quote("stacktrace")).append(":").append(serialize(Arrays.asList(e.getStackTrace())));
-        }
-
-        if (e.getCause() != null && e.getCause() != e) {
-            json.append(",");
-            json.append(quote("cause")).append(":").append(serialize(e.getCause()));
-        }
-
         json.append("}");
 
         return json.toString();


### PR DESCRIPTION
Remove exception stacktrace and cause in rest API response when exception occurs on server side

Closes [BS-15501](https://bonitasoft.atlassian.net/browse/BS-15501) and [BS-15500](https://bonitasoft.atlassian.net/browse/BS-15500)

Added for 7.4 since it causes kind of API break...