### PR TITLE
fix (BS-15536) Refine an existing Resource Permission Mapping fails

### DIFF
--- a/common/src/main/java/org/bonitasoft/console/common/server/preferences/properties/ResourcesPermissionsMapping.java
+++ b/common/src/main/java/org/bonitasoft/console/common/server/preferences/properties/ResourcesPermissionsMapping.java
@@ -50,7 +50,7 @@ public class ResourcesPermissionsMapping extends ConfigurationFile {
 
     public Set<String> getResourcePermissionsWithWildCard(final String method, final String apiName, final String resourceName,
             final List<String> resourceQualifiers) {
-        if (resourceQualifiers != null) {
+        if (resourceQualifiers != null && resourceQualifiers.size() > 0) {
             for (int i = resourceQualifiers.size() - 1; i >= 0; i--) {
                 final List<String> resourceQualifiersWithWildCard = getResourceQualifiersWithWildCard(resourceQualifiers, i);
                 final String key = buildResourceKey(method, apiName, resourceName, resourceQualifiersWithWildCard);
@@ -59,6 +59,9 @@ public class ResourcesPermissionsMapping extends ConfigurationFile {
                     return permissions;
                 }
             }
+            final List<String> reducedResourceQualifiers = new ArrayList<String>(resourceQualifiers);
+            reducedResourceQualifiers.remove(resourceQualifiers.size() - 1);
+            return getResourcePermissionsWithWildCard(method, apiName, resourceName, reducedResourceQualifiers);
         }
         return Collections.emptySet();
     }

--- a/common/src/test/java/org/bonitasoft/console/common/server/preferences/properties/ResourcesPermissionsMappingTest.java
+++ b/common/src/test/java/org/bonitasoft/console/common/server/preferences/properties/ResourcesPermissionsMappingTest.java
@@ -57,16 +57,27 @@ public class ResourcesPermissionsMappingTest {
     @Test
     public void testGetResourcePermissionWithWildCard() throws Exception {
         //given
-        final String fileContent = "POST|bpm/process [Process Deploy]\n" +
-                "POST|bpm/process/*/instantiation [Custom permission]";
+        final String fileContent = "POST|bpm/process/* [Process Deploy]\n" +
+                "POST|bpm/process/*/instantiation [Custom permission]\n" +
+                "PUT|bpm/process/*/expression [Expression update]";
+
         final ResourcesPermissionsMapping resourcesPermissionsMapping = getResourcesPermissionsMapping(fileContent);
 
         //when
+        final Set<String> getWithResourcesQualifier = resourcesPermissionsMapping.getResourcePermissionsWithWildCard("GET", "bpm", "process",
+                Arrays.asList("6"));
+        final Set<String> postWithResourcesQualifier = resourcesPermissionsMapping.getResourcePermissionsWithWildCard("POST", "bpm", "process",
+                Arrays.asList("6"));
         final Set<String> postWithResourcesQualifiers = resourcesPermissionsMapping.getResourcePermissionsWithWildCard("POST", "bpm", "process",
                 Arrays.asList("6", "instantiation"));
+        final Set<String> putWithResourcesQualifiers = resourcesPermissionsMapping.getResourcePermissionsWithWildCard("PUT", "bpm", "process",
+                Arrays.asList("6", "expression", "10"));
 
         //then
+        Assertions.assertThat(getWithResourcesQualifier).isEmpty();
+        Assertions.assertThat(postWithResourcesQualifier).containsOnly("Process Deploy");
         Assertions.assertThat(postWithResourcesQualifiers).containsOnly("Custom permission");
+        Assertions.assertThat(putWithResourcesQualifiers).containsOnly("Expression update");
     }
 
     public static ResourcesPermissionsMapping getResourcesPermissionsMapping(final String fileContent) throws IOException {


### PR DESCRIPTION
- support resources permission mapping with wild card for calls with
compound resources ID with more than 2 elements

Covers [BS-15536](https://bonitasoft.atlassian.net/browse/BS-15536)